### PR TITLE
Resolves #114: Fix wrong failed in process task

### DIFF
--- a/app/scheduler/tasks/base_task.py
+++ b/app/scheduler/tasks/base_task.py
@@ -143,10 +143,8 @@ class BaseTask(GenericActor):
             import_layer = ImportedLayer.objects.filter(task_id__id=task.id)
             if len(import_layer) > 0:
                 imported_results = all(list(map(lambda x: x.status == 'SUCCESS', import_layer)))
-            else:
-                imported_results = False
+                task.status = TaskStatus.SUCCESS if imported_results else TaskStatus.FAILED
 
-            task.status = TaskStatus.SUCCESS if imported_results else TaskStatus.FAILED
             task.progress = 100
             task.end_date = timezone.now()
             task.save()


### PR DESCRIPTION
Bugfixing of the issue related to the process task.
The base task now will look if there are some ImportedLayers available for a specific task_id:
- If not -> will not override the TaskStatus
- if yes -> will set the task FAILED if atleast one import layer is failing