### PR TITLE
Feature/improve validation steps

### DIFF
--- a/app/scheduler/tasks/export_definitions/validations.py
+++ b/app/scheduler/tasks/export_definitions/validations.py
@@ -1,6 +1,9 @@
+import re
+
 import schema
 from .exceptions import ExportConfigError
 from app.scheduler.utils import COMPARISON_OPERATORS_MAPPING
+from typing import Dict
 
 SUPPORTED_VALIDATIONS = ["IF"]
 
@@ -22,31 +25,92 @@ class BaseValidation:
 
 
 class IfValidation(BaseValidation):
+    """
+        If validation, will check if a specific value match the condition.
+        The conditions can be multiple in AND or OR (or both means that both conditions must be True)
+        The validation also accept templated field that must be added into a specific key called "lookup"
+        with "{ column_alias }" as alias.
+        Simple example with AND:
+        {
+            "field": "foo_field",
+            "cond": {
+                "and": [
+                    {"operator": ">", "value": 2},
+                    {"operator": "<", "value": 10},
+                ]
+            },
+        }
+        return True if the value of "foo_field" is greater than 2 and lower than 10
+
+        Simple example with OR:
+        {
+            "field": "foo_field",
+            "cond": {
+                "or": [
+                    {"operator": ">", "value": 2},
+                    {"operator": "<", "value": 10},
+                ]
+            },
+        }
+        return True if the value of "foo_field" is greater than 2 OR lower than 10
+
+        Simple example with AND, OR and templated field:
+        {
+            "field": "foo_field",
+            "cond": {
+                "and": [
+                    {"lookup": "{ bar_field }", "operator": ">", "value": 2},
+                    {"operator": "<", "value": 10},
+                ],
+                "or": [
+                    {"lookup": ">", "value": 3},
+                    {"operator": "<", "value": 25},
+                ]
+            },
+        }
+        return True if
+        - the value of "bar_field" is greater than 2
+        - if the value of bar_field is lower than 10
+        OR if the value of "foo_field" is greater than 3 or lower than 25"
+    """
+
     schema = schema.Schema(
         {
+            "field": str,
             "cond":
-                schema.Or(
-                    {str: [{"operator": str, "value": object}]}
+                schema.And(
+                    {str: [{schema.Optional('lookup'): str, "operator": str, "value": object}]}
                 )
         }
     )
+    re_pattern = re.compile('{\W*(\w+)\W*}')
 
-    def validate(self, value):
+    def validate(self, row: Dict):
         conditions = self.args["cond"]
         and_conditions = conditions.get("and", [])
         or_conditions = conditions.get("or", [])
-        and_result = list(self._validate_list(and_conditions, value))
-        or_result = list(self._validate_list(or_conditions, value))
-        if len(or_result) > 0:
-            return any(or_result + and_result)
-        elif len(and_result) > 0 and len(or_result) == 0:
-            return all(and_result + or_result)
 
-    @staticmethod
-    def _validate_list(conditions, value):
+        and_result = list(self._validate_list(and_conditions, row))
+        or_result = list(self._validate_list(or_conditions, row))
+
+        if len(and_result) > 0 and len(or_result) > 0:
+            return all([and_result, any(or_result)])
+        elif len(or_result) > 0:
+            return all([any(or_result), all(and_result)])
+        elif len(and_result) > 0 and len(or_result) == 0:
+            return all(and_result)
+
+    def _validate_list(self, conditions, row):
+        field_value = row.get(self.args["field"], None)
         for cond in conditions:
+            if "lookup" in cond:
+                lookup_field = re.match(self.re_pattern, cond['lookup'])
+
+                if lookup_field is not None:
+                    field_value = row.get(lookup_field.group(1), None)
+
             operator = COMPARISON_OPERATORS_MAPPING.get(cond["operator"], None)
-            yield operator(value, cond["value"])
+            yield operator(field_value, cond["value"])
 
 
 class ValidationFactory:

--- a/app/tests/tasks/test_query_data_extraction.py
+++ b/app/tests/tasks/test_query_data_extraction.py
@@ -98,10 +98,9 @@ class ExportConfigTest(SimpleTestCase):
             sorted(x["sql_sources"]) for x in self.all_sql_query if x["sheet"] == "Fiumi"
         ]
         # expect to have 3 queries
-        self.assertEqual(3, len(actual[0]))
+        self.assertEqual(2, len(actual[0]))
         self.assertMultiLineEqual(expected_a_fiumi_query, actual[0][0])
         self.assertMultiLineEqual(expected_fiumi_query, actual[0][1])
-        self.assertMultiLineEqual(expected_fiumi_inpotab_query, actual[0][2])
 
     def test_fognat_com_serv_queries_should_be_the_expected_ones(self):
         actual = [
@@ -142,10 +141,9 @@ class ExportConfigTest(SimpleTestCase):
             sorted(x["sql_sources"]) for x in self.all_sql_query if x["sheet"] == "Laghi"
         ]
         # expect to have 3 queries
-        self.assertEqual(3, len(actual[0]))
+        self.assertEqual(2, len(actual[0]))
         self.assertMultiLineEqual(expected_a_laghi_query, actual[0][0])
         self.assertMultiLineEqual(expected_laghi_query, actual[0][1])
-        self.assertMultiLineEqual(expected_laghi_inpotab_query, actual[0][2])
 
     def test_pompaggi_queries_should_be_the_expected_ones(self):
         actual = [
@@ -212,10 +210,9 @@ class ExportConfigTest(SimpleTestCase):
             sorted(x["sql_sources"]) for x in self.all_sql_query if x["sheet"] == "Sorgenti"
         ]
         # expect to have 3 query
-        self.assertEqual(3, len(actual[0]))
+        self.assertEqual(2, len(actual[0]))
         self.assertMultiLineEqual(expected_a_sorgenti_query, actual[0][0])
         self.assertMultiLineEqual(expected_sorgenti_query, actual[0][1])
-        self.assertMultiLineEqual(expected_sorgenti_inpotab_query, actual[0][2])
 
 
 if __name__ == "__main__":

--- a/app/tests/tasks/test_validations.py
+++ b/app/tests/tasks/test_validations.py
@@ -1,5 +1,4 @@
 import unittest
-from unittest import skip
 
 from django.test import SimpleTestCase
 
@@ -9,53 +8,111 @@ from app.scheduler.tasks.export_definitions.validations import ValidationFactory
 class ValidationTestCase(SimpleTestCase):
     def setUp(self) -> None:
         self.validate = ValidationFactory
+        self.field = {"foo_field": 1, "bar_field": 12}
 
-    def test_given_transformation_name_IF_AND_with_true_cond_should_return_the_expected_output(self):
+    def test_given_transformation_name_IF_AND_with_true_cond_should_return_the_expected_output(
+        self,
+    ):
         condition_schema = {
-            "cond": {
-                "and": [
-                    {"operator": "<", "value": "2"}
-                ]
-            }
+            "field": "foo_field",
+            "cond": {"and": [{"operator": "<", "value": 2}]},
         }
-        actual = self.validate.from_name("IF", condition_schema).validate("1")
+        actual = self.validate.from_name("IF", condition_schema).validate(self.field)
         self.assertTrue(actual)
 
-    def test_given_transformation_name_IF_AND_with_false_cond_should_return_the_expected_output(self):
+    def test_given_transformation_name_IF_AND_with_true_cond_and_not_matching_regex_should_return_the_expected_output(
+        self,
+    ):
         condition_schema = {
+            "field": "foo_field",
+            "cond": {"and": [{"lookup": "{bar_field}", "operator": "<", "value": 2}]},
+        }
+        actual = self.validate.from_name("IF", condition_schema).validate(self.field)
+        self.assertFalse(actual)
+
+    def test_given_transformation_name_IF_AND_with_false_cond_should_return_the_expected_output(
+        self,
+    ):
+        condition_schema = {
+            "field": "foo_field",
             "cond": {
                 "and": [
-                    {"operator": "<", "value": "2"},
-                    {"operator": ">", "value": "10"},
+                    {"operator": "<", "value": 2},
+                    {"operator": ">", "value": 10},
                 ]
-            }
+            },
         }
-        actual = self.validate.from_name("IF", condition_schema).validate("1")
+        actual = self.validate.from_name("IF", condition_schema).validate(self.field)
         self.assertFalse(actual)
 
-    def test_given_transformation_name_IF_OR_with_true_cond_should_return_the_expected_output(self):
+    def test_given_transformation_name_IF_OR_with_true_cond_should_return_the_expected_output(
+        self,
+    ):
         condition_schema = {
+            "field": "foo_field",
             "cond": {
                 "or": [
-                    {"operator": "<", "value": "2"},
-                    {"operator": ">", "value": "0"},
+                    {"operator": "<", "value": 2},
+                    {"operator": ">", "value": 0},
                 ]
-            }
+            },
         }
-        actual = self.validate.from_name("IF", condition_schema).validate("1")
+        actual = self.validate.from_name("IF", condition_schema).validate(self.field)
         self.assertTrue(actual)
 
-    def test_given_transformation_name_IF_OR_with_false_cond_should_return_the_expected_output(self):
+    def test_given_transformation_name_IF_OR_with_false_cond_should_return_the_expected_output(
+        self,
+    ):
         condition_schema = {
+            "field": "foo_field",
             "cond": {
                 "or": [
-                    {"operator": ">", "value": "2"},
-                    {"operator": ">", "value": "10"},
+                    {"operator": ">", "value": 2},
+                    {"operator": ">", "value": 10},
                 ]
-            }
+            },
         }
-        actual = self.validate.from_name("IF", condition_schema).validate("1")
+        actual = self.validate.from_name("IF", condition_schema).validate(self.field)
         self.assertFalse(actual)
+
+    def test_given_transformation_name_IF_AND_OR_with_false_cond_should_return_the_expected_output(
+        self,
+    ):
+        condition_schema = {
+            "field": "foo_field",
+            "cond": {
+                "or": [
+                    {"operator": ">", "value": 2},
+                    {"operator": ">", "value": 10},
+                ],
+                "and": [
+                    {"operator": "<", "value": 2},
+                    {"operator": ">", "value": 10},
+                ],
+            },
+        }
+        actual = self.validate.from_name("IF", condition_schema).validate(self.field)
+        self.assertFalse(actual)
+
+    def test_given_transformation_name_IF_AND_OR_with_true_cond_should_return_the_expected_output(
+        self,
+    ):
+        condition_schema = {
+            "field": "foo_field",
+            "cond": {
+                "or": [
+                    {"operator": "=", "value": 1},
+                    {"operator": "<", "value": 100},
+                ],
+                "and": [
+                    {"operator": "<", "value": 10},
+                    {"operator": ">", "value": 0},
+                ],
+            },
+        }
+        self.field = {"foo_field": 5, "bar_field": 12}
+        actual = self.validate.from_name("IF", condition_schema).validate(self.field)
+        self.assertTrue(actual)
 
 
 if __name__ == "__main__":

--- a/app/tests/tasks/test_validations.py
+++ b/app/tests/tasks/test_validations.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest import skip
 
 from django.test import SimpleTestCase
 
@@ -15,7 +16,7 @@ class ValidationTestCase(SimpleTestCase):
     ):
         condition_schema = {
             "field": "foo_field",
-            "cond": {"and": [{"operator": "<", "value": 2}]},
+            "cond": [{"and": [{"operator": "<", "value": 2}]}]
         }
         actual = self.validate.from_name("IF", condition_schema).validate(self.field)
         self.assertTrue(actual)
@@ -25,7 +26,7 @@ class ValidationTestCase(SimpleTestCase):
     ):
         condition_schema = {
             "field": "foo_field",
-            "cond": {"and": [{"lookup": "{bar_field}", "operator": "<", "value": 2}]},
+            "cond": [{"and": [{"lookup": "{bar_field}", "operator": "<", "value": 2}]}],
         }
         actual = self.validate.from_name("IF", condition_schema).validate(self.field)
         self.assertFalse(actual)
@@ -35,12 +36,12 @@ class ValidationTestCase(SimpleTestCase):
     ):
         condition_schema = {
             "field": "foo_field",
-            "cond": {
+            "cond": [{
                 "and": [
                     {"operator": "<", "value": 2},
                     {"operator": ">", "value": 10},
                 ]
-            },
+            }],
         }
         actual = self.validate.from_name("IF", condition_schema).validate(self.field)
         self.assertFalse(actual)
@@ -50,12 +51,12 @@ class ValidationTestCase(SimpleTestCase):
     ):
         condition_schema = {
             "field": "foo_field",
-            "cond": {
+            "cond": [{
                 "or": [
                     {"operator": "<", "value": 2},
                     {"operator": ">", "value": 0},
                 ]
-            },
+            }],
         }
         actual = self.validate.from_name("IF", condition_schema).validate(self.field)
         self.assertTrue(actual)
@@ -65,12 +66,12 @@ class ValidationTestCase(SimpleTestCase):
     ):
         condition_schema = {
             "field": "foo_field",
-            "cond": {
+            "cond": [{
                 "or": [
                     {"operator": ">", "value": 2},
                     {"operator": ">", "value": 10},
                 ]
-            },
+            }],
         }
         actual = self.validate.from_name("IF", condition_schema).validate(self.field)
         self.assertFalse(actual)
@@ -80,7 +81,7 @@ class ValidationTestCase(SimpleTestCase):
     ):
         condition_schema = {
             "field": "foo_field",
-            "cond": {
+            "cond": [{
                 "or": [
                     {"operator": ">", "value": 2},
                     {"operator": ">", "value": 10},
@@ -89,7 +90,7 @@ class ValidationTestCase(SimpleTestCase):
                     {"operator": "<", "value": 2},
                     {"operator": ">", "value": 10},
                 ],
-            },
+            }],
         }
         actual = self.validate.from_name("IF", condition_schema).validate(self.field)
         self.assertFalse(actual)
@@ -99,7 +100,7 @@ class ValidationTestCase(SimpleTestCase):
     ):
         condition_schema = {
             "field": "foo_field",
-            "cond": {
+            "cond": [{
                 "or": [
                     {"operator": "=", "value": 1},
                     {"operator": "<", "value": 100},
@@ -108,11 +109,32 @@ class ValidationTestCase(SimpleTestCase):
                     {"operator": "<", "value": 10},
                     {"operator": ">", "value": 0},
                 ],
-            },
+            }],
         }
         self.field = {"foo_field": 5, "bar_field": 12}
         actual = self.validate.from_name("IF", condition_schema).validate(self.field)
         self.assertTrue(actual)
+
+    def test_given_transformation_name_IF_AND_with_true_multiple_cond_and_not_matching_regex_should_return_the_expected_output(
+        self,
+    ):
+        condition_schema = {
+            "field": "foo_field",
+            "cond": [{"and": [{"operator": "<", "value": 2}]}, {"and": [{"operator": "<", "value": 5}]}],
+        }
+        actual = self.validate.from_name("IF", condition_schema).validate(self.field)
+        self.assertTrue(actual)
+
+    def test_given_transformation_name_IF_AND_with_false_multiple_cond_and_not_matching_regex_should_return_the_expected_output(
+        self,
+    ):
+        condition_schema = {
+            "field": "foo_field",
+            "cond": [{"and": [{"operator": "<", "value": 2}]}, {"and": [{"operator": "<", "value": 5}]}],
+        }
+        self.field = {"foo_field": 100}
+        actual = self.validate.from_name("IF", condition_schema).validate(self.field)
+        self.assertFalse(actual)
 
 
 if __name__ == "__main__":

--- a/app/tests/tasks/test_validations.py
+++ b/app/tests/tasks/test_validations.py
@@ -1,0 +1,62 @@
+import unittest
+from unittest import skip
+
+from django.test import SimpleTestCase
+
+from app.scheduler.tasks.export_definitions.validations import ValidationFactory
+
+
+class ValidationTestCase(SimpleTestCase):
+    def setUp(self) -> None:
+        self.validate = ValidationFactory
+
+    def test_given_transformation_name_IF_AND_with_true_cond_should_return_the_expected_output(self):
+        condition_schema = {
+            "cond": {
+                "and": [
+                    {"operator": "<", "value": "2"}
+                ]
+            }
+        }
+        actual = self.validate.from_name("IF", condition_schema).validate("1")
+        self.assertTrue(actual)
+
+    def test_given_transformation_name_IF_AND_with_false_cond_should_return_the_expected_output(self):
+        condition_schema = {
+            "cond": {
+                "and": [
+                    {"operator": "<", "value": "2"},
+                    {"operator": ">", "value": "10"},
+                ]
+            }
+        }
+        actual = self.validate.from_name("IF", condition_schema).validate("1")
+        self.assertFalse(actual)
+
+    def test_given_transformation_name_IF_OR_with_true_cond_should_return_the_expected_output(self):
+        condition_schema = {
+            "cond": {
+                "or": [
+                    {"operator": "<", "value": "2"},
+                    {"operator": ">", "value": "0"},
+                ]
+            }
+        }
+        actual = self.validate.from_name("IF", condition_schema).validate("1")
+        self.assertTrue(actual)
+
+    def test_given_transformation_name_IF_OR_with_false_cond_should_return_the_expected_output(self):
+        condition_schema = {
+            "cond": {
+                "or": [
+                    {"operator": ">", "value": "2"},
+                    {"operator": ">", "value": "10"},
+                ]
+            }
+        }
+        actual = self.validate.from_name("IF", condition_schema).validate("1")
+        self.assertFalse(actual)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/export/config/current/sheet_configs/config_accumuli.json
+++ b/export/config/current/sheet_configs/config_accumuli.json
@@ -128,8 +128,36 @@
         {"id": "44500","transformation": {"func": "DIRECT", "params": {"field": "anno_costr"}}},
         {"id": "44600","transformation": {"func": "DIRECT", "params": {"field": "anno_ristr"}}},
         {"id": "45000","transformation": {"func": "DIRECT", "params": {"field": "volume"}}},
-        {"id": "44200","transformation": {"func": "DIRECT", "params": {"field": "quota"}}},
-        {"id": "45100","transformation": {"func": "DIRECT", "params": {"field": "quota_fondo"}}},
+        {"id": "44200","transformation": {"func": "DIRECT", "params": {"field": "quota"}},
+            "validations": [{
+                    "func": "IF",
+                    "params": {
+                        "field": "quota",
+                        "cond": {
+                            "and": [
+                                {"operator": ">", "value": 0}
+                            ]
+                        }
+                    },
+                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: must be greater than 0"
+                }
+            ]
+        },
+        {"id": "45100","transformation": {"func": "DIRECT", "params": {"field": "quota_fondo"}},
+            "validations": [{
+                    "func": "IF",
+                    "params": {
+                        "field": "quota_fondo",
+                        "cond": {
+                            "and": [
+                                {"operator": ">", "value": 0}
+                            ]
+                        }
+                    },
+                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: must be greater than 0"
+                }
+            ]
+        },
         {"id": "45300","transformation": {"func": "DIRECT", "params": {"field": "sn_strum_mis_liv"}}},
         {"id": "45400","transformation": {"func": "DIRECT", "params": {"field": "sn_strum_mis_port"}}},
         {"id": "45600","transformation": {"func": "DIRECT", "params": {"field": "anno_instal_clor"}}},
@@ -138,7 +166,22 @@
         {"id": "43900","transformation": {"func": "DIRECT", "params": {"field": "transformed_y_geom"}}},
         {"id": "44000","transformation": {"func": "DIRECT", "params": {"field": "transformed_x_geom"}}},
 
-        {"id": "44700", "transformation": {"func": "DOMAIN", "params": { "field": "d_stato_cons", "domain_name": "D_STATO_CONS" }}},
+        {"id": "44700", "transformation": {"func": "DOMAIN", "params": { "field": "d_stato_cons", "domain_name": "D_STATO_CONS" }},
+            "validations": [{
+                    "func": "IF",
+                    "params": {
+                        "field": "d_stato_cons",
+                        "cond": {
+                            "and": [
+                                {"lookup": "{anno_ristr}" ,"operator": ">=", "value": 2014},
+                                {"operator": ">=", "value": 3}
+                            ]
+                        }
+                    },
+                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: value lower than 3"
+                }
+            ]
+        },
 
         {"id": "44800","transformation": {"func": "DOMAIN", "params": {"field": "d_ubicazione", "domain_name": "D_UBICAZ_OPERA"}}},
         {"id": "44900","transformation": {"func": "DOMAIN", "params": {"field": "d_materiale", "domain_name": "D_MATERIALE"}}},
@@ -147,7 +190,22 @@
 
         {"id": "45800","transformation": {"func": "DOMAIN", "params": {"field": "d_stato", "domain_name": "D_STATO"}}},
         {"id": "45900","transformation": {"func": "DOMAIN", "params": {"field": "a_anno_costr", "domain_name": "D_AFFIDABILITA"}}},
-        {"id": "46000","transformation": {"func": "DOMAIN", "params": {"field": "a_anno_ristr", "domain_name": "D_AFFIDABILITA"}}},
+        {"id": "46000","transformation": {"func": "DOMAIN", "params": {"field": "a_anno_ristr", "domain_name": "D_AFFIDABILITA"}},
+            "validations": [{
+                    "func": "IF",
+                    "params": {
+                        "field": "a_anno_ristr",
+                        "cond": {
+                            "and": [
+                                {"lookup": "{anno_ristr}" ,"operator": ">=", "value": 2002},
+                                {"operator": "=", "value": "A"}
+                            ]
+                        }
+                    },
+                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: value lower than 3"
+                }
+            ]
+        },
         {"id": "46100","transformation": {"func": "DOMAIN", "params": {"field": "a_volume", "domain_name": "D_AFFIDABILITA"}}}
     ]
 }


### PR DESCRIPTION
WIth this PR I want to:
- Permit to handle the validation steps for a specific field in export of the configuration.

It's quite different from the previous one so we need to update also the client's documentation , since the two different nature of the Validation/Transformation, was not possible to inerith them.
I created a new IFValidation function which will handle:
- Complex if with multiple condition in AND
- Complex if with multiple condition in OR
- Complex if with multiple condition with the combination of AND + OR
- Complex if that the condition depends from a value of another field

I take ispiration from the Transformations made by Michal so should be really straightforward as a change.

Next-step: test it in the export files
```

Simple example with AND:
        {
            "field": "foo_field",
            "cond": [{
                "and": [
                    {"operator": ">", "value": 2},
                    {"operator": "<", "value": 10},
                ]
            }],
        }
        return True if the value of "foo_field" is greater than 2 and lower than 10

 Simple example with OR:
        {
            "field": "foo_field",
            "cond": [{
                "or": [
                    {"operator": ">", "value": 2},
                    {"operator": "<", "value": 10},
                ]
            }],
        }
        return True if the value of "foo_field" is greater than 2 OR lower than 10

Simple example with AND, OR and templated field:
        {
            "field": "foo_field",
            "cond": [{
                "and": [
                    {"lookup": "{ bar_field }", "operator": ">", "value": 2},
                    {"operator": "<", "value": 10},
                ],
                "or": [
                    {"lookup": ">", "value": 3},
                    {"operator": "<", "value": 25},
                ]
            }],
        }
        return True if
        - the value of "bar_field" is greater than 2
        - if the value of bar_field is lower than 10
        OR if the value of "foo_field" is greater than 3 or lower than 25

Simple example with AND:
        {
            "field": "foo_field",
            "cond": [{
                "and": [
                    {"operator": ">", "value": 2},
                    {"operator": "<", "value": 10},
                ]
            },
           {
                "and": [
                    {"operator": "!=", "value": 3},
                    {"operator": "<", "value": 9},
                ]
            }],
        }
        return True if all conditions are True
```