### PR TITLE
Bugfix/log issues

### DIFF
--- a/app/scheduler/tasks/export_definitions/config_scraper/config_scraper_xls.py
+++ b/app/scheduler/tasks/export_definitions/config_scraper/config_scraper_xls.py
@@ -133,6 +133,7 @@ class XlsExportConfig(BaseExportConfig):
             )
             column.update({
                     "transformer": transformer,
+                    "alias": transformation["params"].get("field", None),
                     "warning": transformation.get("warning", None)
                 })
 

--- a/app/scheduler/tasks/export_definitions/export/export_base.py
+++ b/app/scheduler/tasks/export_definitions/export/export_base.py
@@ -43,7 +43,7 @@ class ExportBase:
         )
         logger = logging.getLogger(__name__)
         hdlr = logging.FileHandler(logfile_path.absolute())
-        formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
+        formatter = logging.Formatter("%(levelname)s, %(message)s")
         hdlr.setFormatter(formatter)
         logger.addHandler(hdlr)
         logger.setLevel(logging.INFO)

--- a/app/scheduler/tasks/export_definitions/export/export_xls.py
+++ b/app/scheduler/tasks/export_definitions/export/export_xls.py
@@ -192,7 +192,7 @@ class ExportXls(ExportBase):
                             self.logger.error(
                                 f"Validation: Error occurred during validation of column with "
                                 f"ID '{column['id']}' in row '{first_empty_row}' in sheet '{sheet['sheet']}': "
-                                f"{type(e).__name__}: {e}."
+                                f"{type(e).__name__}: {e.args[0]}.".strip("\n")
                             )
                 # insert sheet_row into excel
                 for column_id, value in sheet_row.items():
@@ -209,7 +209,7 @@ class ExportXls(ExportBase):
                         self.logger.error(
                             f"Excel Config: Error occurred during inserting value to the column with "
                             f"ID '{column_id}' in row '{first_empty_row}' in sheet '{sheet['sheet']}': "
-                            f"{type(e).__name__}: {e}."
+                            f"{type(e).__name__}: {e.args[0]}.".strip("\n")
                         )
 
                 first_empty_row += 1

--- a/app/scheduler/tasks/export_definitions/export/export_xls.py
+++ b/app/scheduler/tasks/export_definitions/export/export_xls.py
@@ -124,7 +124,7 @@ class ExportXls(ExportBase):
                 sheet_row = {}
 
                 for column in sheet["columns"]:
-                    message = "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Error: {E}" if not column['warning'] else column['warning']
+                    message = "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Error: {E}" if not column['warning'] else column['warning']
                     try:
                         transformed_value = column["transformer"].apply(
                             row=raw_data_row, domains=all_domains
@@ -134,10 +134,7 @@ class ExportXls(ExportBase):
                     except TypeError as e:
                         transformed_value = None
                     except Exception as e:
-                        warning_log = message or "Foglio: {SHEET}, Riga:{ROW}, {CODICE_ATO}, Campo: {FIELD}: Transformation error"
-
-                        if '{CODICE_ATO}' not in warning_log:
-                            warning_log = warning_log.replace(", Campo: ", ", Codice_ato: {CODICE_ATO}, Campo: ")
+                        warning_log = message or "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Transformation error"
 
                         warning_to_log = (
                             warning_log.replace("{SHEET}", sheet["sheet"])
@@ -145,7 +142,7 @@ class ExportXls(ExportBase):
                             .replace("{FIELD}", column.get("alias", column['id']))
                             .replace("{CODICE_ATO}", raw_data_row.get("codice_ato", ""))
                             .replace("{E}", e.args[0].strip('\n'))
-                            .replace("ref_year", str(self.ref_year or datetime.today().year))
+                            .replace("{REF_YEAR}", str(self.ref_year or datetime.today().year))
                         )
 
                         if '{custom:' in warning_log:
@@ -175,16 +172,13 @@ class ExportXls(ExportBase):
                                 # )
                                 # {custom:codice_ato} ->
 
-                                warning_log = message or "Foglio: {SHEET}, Riga:{ROW}, {CODICE_ATO}, Campo: {FIELD}: Validation error"
-
-                                if '{CODICE_ATO}' not in warning_log:
-                                    warning_log = warning_log.replace(", Campo: ", ", Codice_ato: {CODICE_ATO}, Campo: ")
+                                warning_log = message or "Foglio: {SHEET}, Riga:{ROW}, Codice ato: {CODICE_ATO}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Validation error"
 
                                 warning_to_log = warning_log.replace("{SHEET}", sheet["sheet"])\
                                     .replace("{ROW}", str(first_empty_row))\
                                     .replace("{FIELD}", column.get("alias", column['id']))\
                                     .replace("{CODICE_ATO}", raw_data_row.get("codice_ato", ""))\
-                                    .replace("ref_year", str(self.ref_year or datetime.today().year))
+                                    .replace("{REF_YEAR}", str(self.ref_year or datetime.today().year))
 
                                 if '{custom:' in warning_log:
                                     re_pattern = re.compile('.*{custom:(.*)},')

--- a/export/config/current/sheet_configs/config_accumuli.json
+++ b/export/config/current/sheet_configs/config_accumuli.json
@@ -132,8 +132,8 @@
                         "field": "44500",
                         "cond": [{
                             "or": [
-                                {"operator": ">=", "value": "{REF_YEAR}"},
-                                {"operator": "!=", "value": 9999}
+                                {"operator": "<=", "value": "{REF_YEAR}"},
+                                {"operator": "=", "value": 9999}
                             ]
                         }]
                     },
@@ -187,9 +187,9 @@
                             ]
                         },
                         {
-                            "and": [
-                                {"operator": ">=", "value": "{REF_YEAR}"},
-                                {"operator": "!=", "value": 9999}
+                            "or": [
+                                {"operator": "<=", "value": "{REF_YEAR}"},
+                                {"operator": "=", "value": 9999}
                             ]
                         }]
                     },
@@ -209,9 +209,9 @@
                             ]
                         },
                         {
-                            "and": [
+                            "or": [
                                 {"operator": ">=", "value": 2020},
-                                {"operator": "!=", "value": 9800}
+                                {"operator": "=", "value": 9800}
                             ]
                         }]
                     },
@@ -281,7 +281,7 @@
                         },
                         {
                             "and": [
-                                {"lookup": "{44500}" ,"operator": ">=", "value": "{REF_YEAR}"},
+                                {"lookup": "{44500}" ,"operator": ">=", "value": 2002},
                                 {"lookup": "{44500}" ,"operator": "!=", "value": 9999},
                                 {"operator": "=", "value": "A"}
                             ]
@@ -297,7 +297,7 @@
                     "params": {
                         "field": "46000",
                         "cond": [{
-                            "and": [
+                            "or": [
                                 {"lookup": "{44600}" ,"operator": ">=", "value": 2002},
                                 {"operator": "=", "value": "A"}
                             ]

--- a/export/config/current/sheet_configs/config_accumuli.json
+++ b/export/config/current/sheet_configs/config_accumuli.json
@@ -235,7 +235,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: value lower than 3 or ref year not valid"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: value lower than 3 or ref year: {REF_YEAR} not valid"
                 }
             ]
         },

--- a/export/config/current/sheet_configs/config_accumuli.json
+++ b/export/config/current/sheet_configs/config_accumuli.json
@@ -137,7 +137,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: year not valid}"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: year not valid}"
                 }
             ]
         },
@@ -154,7 +154,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: must be greater than 0"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: must be greater than 0"
                 }
             ]
         },
@@ -169,7 +169,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: must be greater than 0"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: must be greater than 0"
                 }
             ]
         },
@@ -193,7 +193,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: unexpected value"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: unexpected value"
                 }
             ]
         },
@@ -215,7 +215,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: unexpected value"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: unexpected value"
                 }
             ]
         },
@@ -235,7 +235,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: value lower than 3 or ref year not valid"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: value lower than 3 or ref year not valid"
                 }
             ]
         },
@@ -262,7 +262,7 @@
                         }
                         ]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: value is 1"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: value is 1"
                 }
             ]
         },
@@ -287,7 +287,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: value is not A or X"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: value is not A or X"
                 }
             ]
         },
@@ -303,7 +303,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: value is not A"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: value is not A"
                 }
             ]
         },

--- a/export/config/current/sheet_configs/config_accumuli.json
+++ b/export/config/current/sheet_configs/config_accumuli.json
@@ -137,7 +137,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: year not valid}"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: year not valid}"
                 }
             ]
         },
@@ -154,7 +154,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: must be greater than 0"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: must be greater than 0"
                 }
             ]
         },
@@ -169,7 +169,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: must be greater than 0"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: must be greater than 0"
                 }
             ]
         },
@@ -193,7 +193,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: unexpected value"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: unexpected value"
                 }
             ]
         },
@@ -215,7 +215,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: unexpected value"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: unexpected value"
                 }
             ]
         },
@@ -235,7 +235,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: value lower than 3 or ref year not valid"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: value lower than 3 or ref year not valid"
                 }
             ]
         },
@@ -262,7 +262,7 @@
                         }
                         ]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: value is 1"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: value is 1"
                 }
             ]
         },
@@ -287,7 +287,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: value is not A or X"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: value is not A or X"
                 }
             ]
         },
@@ -303,7 +303,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: value is not A"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: value is not A"
                 }
             ]
         },

--- a/export/config/current/sheet_configs/config_addut_tronchi.json
+++ b/export/config/current/sheet_configs/config_addut_tronchi.json
@@ -71,7 +71,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is 2014 and the value is null"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is 2014 and the value is null"
                 }
             ]
         },
@@ -88,7 +88,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is 2002 and the value is null"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is 2002 and the value is null"
                 }
             ]},
 
@@ -114,7 +114,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is minor of the ref_year and is not 9999"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Value is minor of the {REF_YEAR} and is not 9999"
                 }
             ]},
 

--- a/export/config/current/sheet_configs/config_addut_tronchi.json
+++ b/export/config/current/sheet_configs/config_addut_tronchi.json
@@ -71,7 +71,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is 2014 and the value is null"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is 2014 and the value is null"
                 }
             ]
         },
@@ -88,7 +88,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is 2002 and the value is null"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is 2002 and the value is null"
                 }
             ]},
 
@@ -114,7 +114,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Value is minor of the ref_year and is not 9999"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is minor of the ref_year and is not 9999"
                 }
             ]},
 

--- a/export/config/current/sheet_configs/config_addut_tronchi.json
+++ b/export/config/current/sheet_configs/config_addut_tronchi.json
@@ -65,7 +65,7 @@
                     "params": {
                         "field": "41200",
                         "cond": [{
-                            "and": [
+                            "or": [
                               {"lookup": "{41500}" ,"operator": ">=", "value": 2014},
                               {"operator":  "!=", "value": null}
                             ]
@@ -82,7 +82,7 @@
                     "params": {
                         "field": "41400",
                         "cond": [{
-                            "and": [
+                            "or": [
                               {"lookup": "{41500}" ,"operator": ">=", "value": 2002},
                               {"operator":  "!=", "value": null}
                             ]
@@ -108,9 +108,9 @@
                     "params": {
                         "field": "41400",
                         "cond": [{
-                            "and": [
+                            "or": [
                               {"operator": "<=", "value": "{REF_YEAR}"},
-                              {"operator": "!=", "value": 9999}
+                              {"operator": "=", "value": 9999}
                             ]
                         }]
                     },

--- a/export/config/current/sheet_configs/config_adduttrici.json
+++ b/export/config/current/sheet_configs/config_adduttrici.json
@@ -119,7 +119,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Value is minor of the ref_year and is not 9800"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is minor of the ref_year and is not 9800"
                 }
             ]},
         { "id": "40200", "transformation": { "func": "DIRECT",  "params": { "field": "anno_ristr_clor" } }},
@@ -138,7 +138,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Value 1 is not permitted"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value 1 is not permitted"
                 }
             ]},
         {"id":"40300", "transformation":{"func":"DOMAIN", "params":{"field":"d_stato", "domain_name": "D_STATO"}}},

--- a/export/config/current/sheet_configs/config_adduttrici.json
+++ b/export/config/current/sheet_configs/config_adduttrici.json
@@ -109,7 +109,7 @@
                         "cond": [{
                             "or": [
                               {"operator": "<=", "value": "{REF_YEAR}"},
-                              {"operator": "!=", "value": 9999}
+                              {"operator": "=", "value": 9999}
                             ]
                         },
                         {

--- a/export/config/current/sheet_configs/config_adduttrici.json
+++ b/export/config/current/sheet_configs/config_adduttrici.json
@@ -119,7 +119,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is minor of the ref_year and is not 9800"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Value is minor of the {REF_YEAR} and is not 9800"
                 }
             ]},
         { "id": "40200", "transformation": { "func": "DIRECT",  "params": { "field": "anno_ristr_clor" } }},
@@ -138,7 +138,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value 1 is not permitted"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Value 1 is not permitted"
                 }
             ]},
         {"id":"40300", "transformation":{"func":"DOMAIN", "params":{"field":"d_stato", "domain_name": "D_STATO"}}},

--- a/export/config/current/sheet_configs/config_collett_tronchi.json
+++ b/export/config/current/sheet_configs/config_collett_tronchi.json
@@ -77,7 +77,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is Null and data_esercizio is greater than 2014"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: field is Null and data_esercizio is greater than 2014"
                 }
             ]},
         {"id": "70000", "transformation": {"func": "DOMAIN", "params": { "field": "id_conservazione", "domain_name": "D_STATO_CONS" }}},
@@ -93,7 +93,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is Null and data_esercizio is greater than 2002"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: field is Null and data_esercizio is greater than 2002"
                 }
             ]},
 
@@ -119,7 +119,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is minor of the ref_year and is not 9999"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Value is minor of the {REF_YEAR} and is not 9999"
                 }
             ]},
         {"id": "70400", "transformation": {"func": "DIRECT", "params": { "field": "lunghezza" }}},
@@ -151,7 +151,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is not 0"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: field is not 0"
                 }
             ]}
      ]

--- a/export/config/current/sheet_configs/config_collett_tronchi.json
+++ b/export/config/current/sheet_configs/config_collett_tronchi.json
@@ -113,9 +113,9 @@
                     "params": {
                         "field": "70200",
                         "cond": [{
-                            "and": [
-                              {"operator": ">=", "value": "{REF_YEAR}"},
-                              {"operator": "!=", "value": 9999}
+                            "or": [
+                              {"operator": "<=", "value": "{REF_YEAR}"},
+                              {"operator": "=", "value": 9999}
                             ]
                         }]
                     },

--- a/export/config/current/sheet_configs/config_collett_tronchi.json
+++ b/export/config/current/sheet_configs/config_collett_tronchi.json
@@ -77,7 +77,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: field is Null and data_esercizio is greater than 2014"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is Null and data_esercizio is greater than 2014"
                 }
             ]},
         {"id": "70000", "transformation": {"func": "DOMAIN", "params": { "field": "id_conservazione", "domain_name": "D_STATO_CONS" }}},
@@ -93,7 +93,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: field is Null and data_esercizio is greater than 2002"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is Null and data_esercizio is greater than 2002"
                 }
             ]},
 
@@ -119,7 +119,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Value is minor of the ref_year and is not 9999"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is minor of the ref_year and is not 9999"
                 }
             ]},
         {"id": "70400", "transformation": {"func": "DIRECT", "params": { "field": "lunghezza" }}},
@@ -151,7 +151,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: field is not 0"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is not 0"
                 }
             ]}
      ]

--- a/export/config/current/sheet_configs/config_collettori.json
+++ b/export/config/current/sheet_configs/config_collettori.json
@@ -108,7 +108,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Value is minor of the ref_year and is not 9800"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is minor of the ref_year and is not 9800"
                 }
             ]},
         { "id": "68500", "transformation": { "func": "DIRECT", "params": { "field": "vol_idraulici" } } },
@@ -123,7 +123,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: field is not 0"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is not 0"
                 }
             ]},
         { "id": "68700", "transformation": { "func": "DIRECT", "params": { "field": "n_scar_piena" } } },

--- a/export/config/current/sheet_configs/config_collettori.json
+++ b/export/config/current/sheet_configs/config_collettori.json
@@ -108,7 +108,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is minor of the ref_year and is not 9800"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Value is minor of the {REF_YEAR} and is not 9800"
                 }
             ]},
         { "id": "68500", "transformation": { "func": "DIRECT", "params": { "field": "vol_idraulici" } } },
@@ -123,7 +123,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is not 0"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: field is not 0"
                 }
             ]},
         { "id": "68700", "transformation": { "func": "DIRECT", "params": { "field": "n_scar_piena" } } },

--- a/export/config/current/sheet_configs/config_depurat_pompe.json
+++ b/export/config/current/sheet_configs/config_depurat_pompe.json
@@ -38,7 +38,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: field greater than ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field greater than ref_year"
                 }
             ]},
         {"id": "81400","transformation": { "func": "DIRECT", "params": { "field": "anno_ristr" }}, "validations": [{
@@ -52,7 +52,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: field greater than ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field greater than ref_year"
                 }
             ]},
         {"id": "81500","transformation": { "func": "DIRECT", "params": { "field": "potenza" }}},
@@ -75,7 +75,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: field is not A or X"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is not A or X"
                 }
             ]},
         {"id": "82000","transformation": { "func": "DIRECT", "params": { "field": "a_anno_ristr" }}, "validations": [{
@@ -89,7 +89,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: field is not A"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is not A"
                 }
             ]},
         {"id": "82100","transformation": { "func": "DIRECT", "params": { "field": "a_potenza" }}},

--- a/export/config/current/sheet_configs/config_depurat_pompe.json
+++ b/export/config/current/sheet_configs/config_depurat_pompe.json
@@ -38,7 +38,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field greater than ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: field greater than {REF_YEAR}"
                 }
             ]},
         {"id": "81400","transformation": { "func": "DIRECT", "params": { "field": "anno_ristr" }}, "validations": [{
@@ -52,7 +52,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field greater than ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: field greater than {REF_YEAR}"
                 }
             ]},
         {"id": "81500","transformation": { "func": "DIRECT", "params": { "field": "potenza" }}},
@@ -75,7 +75,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is not A or X"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: field is not A or X"
                 }
             ]},
         {"id": "82000","transformation": { "func": "DIRECT", "params": { "field": "a_anno_ristr" }}, "validations": [{
@@ -89,7 +89,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is not A"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: field is not A"
                 }
             ]},
         {"id": "82100","transformation": { "func": "DIRECT", "params": { "field": "a_potenza" }}},

--- a/export/config/current/sheet_configs/config_depurat_pompe.json
+++ b/export/config/current/sheet_configs/config_depurat_pompe.json
@@ -32,9 +32,9 @@
                     "params": {
                         "field": "81300",
                         "cond": [{
-                            "and": [
-                              {"operator": ">=", "value": "{REF_YEAR}"},
-                              {"operator":  "!=", "value": 9999}
+                            "or": [
+                              {"operator": "<=", "value": "{REF_YEAR}"},
+                              {"operator":  "=", "value": 9999}
                             ]
                         }]
                     },
@@ -46,9 +46,9 @@
                     "params": {
                         "field": "81400",
                         "cond": [{
-                            "and": [
-                              {"operator": ">=", "value": "{REF_YEAR}"},
-                              {"operator":  "!=", "value": 9800}
+                            "or": [
+                              {"operator": "<=", "value": "{REF_YEAR}"},
+                              {"operator":  "=", "value": 9800}
                             ]
                         }]
                     },

--- a/export/config/current/sheet_configs/config_depuratori.json
+++ b/export/config/current/sheet_configs/config_depuratori.json
@@ -308,7 +308,7 @@
                         "cond": [{
                             "or": [
                               {"operator": "<=", "value": "{REF_YEAR}"},
-                              {"operator": "!=", "value": 9999}
+                              {"operator": "=", "value": 9999}
                             ]
                         }]
                     },
@@ -335,8 +335,8 @@
                         "field": "73000",
                         "cond": [{
                             "or": [
-                              {"operator": ">=", "value": "{REF_YEAR}"},
-                              {"operator":  "!=", "value": 9800}
+                              {"operator": "<=", "value": "{REF_YEAR}"},
+                              {"operator":  "=", "value": 9800}
                             ]
                         }]
                     },

--- a/export/config/current/sheet_configs/config_depuratori.json
+++ b/export/config/current/sheet_configs/config_depuratori.json
@@ -297,7 +297,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is 0"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: field is 0"
                 }
             ]},
         {"id": "72400", "transformation": {"func": "DIRECT", "params": { "field": "denominazi" }}},
@@ -312,7 +312,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is minor of the ref_year and is not 9999"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Value is minor of the {REF_YEAR} and is not 9999"
                 }
             ]},
         {"id": "72800", "transformation": {"func": "DIRECT", "params": { "field": "anno_ristr_civ" }}, "validations": [{
@@ -326,7 +326,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is minor of the ref_year and is not 9800"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Value is minor of the {REF_YEAR} and is not 9800"
                 }
             ]},
         {"id": "73000", "transformation": {"func": "DIRECT", "params": { "field": "anno_ristr_elmec" }}, "validations": [{
@@ -340,7 +340,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field greater than ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field greater than {REF_YEAR}"
                 }
             ]},
         {"id": "73200", "transformation": {"func": "DIRECT", "params": { "field": "pot_prog" }}},
@@ -355,7 +355,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is not greater than 0"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: field is not greater than 0"
                 }
             ]},
         {"id": "73500", "transformation": {"func": "DIRECT", "params": { "field": "conc_co2_ing" }}},
@@ -375,7 +375,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is not 0"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: field is not 0"
                 }
             ]},
         {"id": "74600", "transformation": {"func": "DIRECT", "params": { "field": "n_linee_acq" }}},
@@ -441,7 +441,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is not greater than 3"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: field is not greater than 3"
                 }
             ]},
         {"id": "73100", "transformation": {"func": "DOMAIN", "params": { "field": "d_stato_cons_elmec", "domain_name": "D_STATO_CONS" }}, "validations": [{
@@ -455,7 +455,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is not greater than 3"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: field is not greater than 3"
                 }
             ]},
         {"id": "73900", "transformation": {"func": "DOMAIN", "params": { "field": "d_telecont", "domain_name": "D_TELECONT" }}},
@@ -482,7 +482,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not X or A"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is not X or A"
                 }
             ]},
         {"id": "79200", "transformation": {"func": "DOMAIN", "params": { "field": "a_anno_ristr_civ", "domain_name": "D_AFFIDABILITA" }}, "validations": [{
@@ -496,7 +496,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not A"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is not A"
                 }
             ]},
         {"id": "79300", "transformation": {"func": "DOMAIN", "params": { "field": "a_anno_ristr_elmec", "domain_name": "D_AFFIDABILITA" }}, "validations": [{
@@ -510,7 +510,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not A"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is not A"
                 }
             ]},
         {"id": "79400", "transformation": {"func": "DOMAIN", "params": { "field": "a_pot_prog", "domain_name": "D_AFFIDABILITA" }}},

--- a/export/config/current/sheet_configs/config_depuratori.json
+++ b/export/config/current/sheet_configs/config_depuratori.json
@@ -297,7 +297,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: field is 0"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is 0"
                 }
             ]},
         {"id": "72400", "transformation": {"func": "DIRECT", "params": { "field": "denominazi" }}},
@@ -312,7 +312,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Value is minor of the ref_year and is not 9999"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is minor of the ref_year and is not 9999"
                 }
             ]},
         {"id": "72800", "transformation": {"func": "DIRECT", "params": { "field": "anno_ristr_civ" }}, "validations": [{
@@ -326,7 +326,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Value is minor of the ref_year and is not 9800"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is minor of the ref_year and is not 9800"
                 }
             ]},
         {"id": "73000", "transformation": {"func": "DIRECT", "params": { "field": "anno_ristr_elmec" }}, "validations": [{
@@ -340,7 +340,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field greater than ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field greater than ref_year"
                 }
             ]},
         {"id": "73200", "transformation": {"func": "DIRECT", "params": { "field": "pot_prog" }}},
@@ -355,7 +355,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: field is not greater than 0"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is not greater than 0"
                 }
             ]},
         {"id": "73500", "transformation": {"func": "DIRECT", "params": { "field": "conc_co2_ing" }}},
@@ -375,7 +375,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: field is not 0"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is not 0"
                 }
             ]},
         {"id": "74600", "transformation": {"func": "DIRECT", "params": { "field": "n_linee_acq" }}},
@@ -441,7 +441,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: field is not greater than 3"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is not greater than 3"
                 }
             ]},
         {"id": "73100", "transformation": {"func": "DOMAIN", "params": { "field": "d_stato_cons_elmec", "domain_name": "D_STATO_CONS" }}, "validations": [{
@@ -455,7 +455,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: field is not greater than 3"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is not greater than 3"
                 }
             ]},
         {"id": "73900", "transformation": {"func": "DOMAIN", "params": { "field": "d_telecont", "domain_name": "D_TELECONT" }}},
@@ -482,7 +482,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is not X or A"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not X or A"
                 }
             ]},
         {"id": "79200", "transformation": {"func": "DOMAIN", "params": { "field": "a_anno_ristr_civ", "domain_name": "D_AFFIDABILITA" }}, "validations": [{
@@ -496,7 +496,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is not A"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not A"
                 }
             ]},
         {"id": "79300", "transformation": {"func": "DOMAIN", "params": { "field": "a_anno_ristr_elmec", "domain_name": "D_AFFIDABILITA" }}, "validations": [{
@@ -510,7 +510,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is not A"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not A"
                 }
             ]},
         {"id": "79400", "transformation": {"func": "DOMAIN", "params": { "field": "a_pot_prog", "domain_name": "D_AFFIDABILITA" }}},

--- a/export/config/current/sheet_configs/config_distrib_tronchi.json
+++ b/export/config/current/sheet_configs/config_distrib_tronchi.json
@@ -66,7 +66,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is null"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is null"
                 }
             ]},
         {"id": "56700", "transformation": {"func": "DOMAIN", "params": { "field": "id_conservazione", "domain_name": "D_STATO_CONS" }}},
@@ -82,7 +82,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is null"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is null"
                 }
             ]},
 
@@ -108,7 +108,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field greater than ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field greater than ref_year"
                 }
             ]},
         {"id": "57100", "transformation": {"func": "DIRECT", "params": { "field": "id_materiale" }}},

--- a/export/config/current/sheet_configs/config_distrib_tronchi.json
+++ b/export/config/current/sheet_configs/config_distrib_tronchi.json
@@ -66,7 +66,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is null"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is null"
                 }
             ]},
         {"id": "56700", "transformation": {"func": "DOMAIN", "params": { "field": "id_conservazione", "domain_name": "D_STATO_CONS" }}},
@@ -82,7 +82,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is null"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is null"
                 }
             ]},
 
@@ -108,7 +108,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field greater than ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field greater than {REF_YEAR}"
                 }
             ]},
         {"id": "57100", "transformation": {"func": "DIRECT", "params": { "field": "id_materiale" }}},

--- a/export/config/current/sheet_configs/config_distrib_tronchi.json
+++ b/export/config/current/sheet_configs/config_distrib_tronchi.json
@@ -103,8 +103,8 @@
                         "field": "56900",
                         "cond": [{
                             "or": [
-                              {"operator": ">=", "value": "{REF_YEAR}"},
-                              {"operator":  "!=", "value": 9999}
+                              {"operator": "<=", "value": "{REF_YEAR}"},
+                              {"operator":  "=", "value": 9999}
                             ]
                         }]
                     },

--- a/export/config/current/sheet_configs/config_distribuzioni.json
+++ b/export/config/current/sheet_configs/config_distribuzioni.json
@@ -188,7 +188,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Value is minor of the ref_year and is not 9800"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is minor of the ref_year and is not 9800"
                 }
             ]},
         { "id": "55300", "transformation": { "func": "DOMAIN", "params": { "field": "d_stato", "domain_name": "D_STATO" } }},

--- a/export/config/current/sheet_configs/config_distribuzioni.json
+++ b/export/config/current/sheet_configs/config_distribuzioni.json
@@ -188,7 +188,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is minor of the ref_year and is not 9800"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Value is minor of the {REF_YEAR} and is not 9800"
                 }
             ]},
         { "id": "55300", "transformation": { "func": "DOMAIN", "params": { "field": "d_stato", "domain_name": "D_STATO" } }},

--- a/export/config/current/sheet_configs/config_fiumi.json
+++ b/export/config/current/sheet_configs/config_fiumi.json
@@ -235,7 +235,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is 0"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is 0"
                 }
             ]},
         {"id": "1800","transformation": { "func": "DIRECT", "params": { "field": "bacino"}}},
@@ -251,7 +251,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is 0"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is 0"
                 }
             ]},
         {"id": "2300","transformation": { "func": "DIRECT", "params": { "field": "port_industr"}}},

--- a/export/config/current/sheet_configs/config_fiumi.json
+++ b/export/config/current/sheet_configs/config_fiumi.json
@@ -235,7 +235,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is 0"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is 0"
                 }
             ]},
         {"id": "1800","transformation": { "func": "DIRECT", "params": { "field": "bacino"}}},
@@ -251,7 +251,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is 0"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is 0"
                 }
             ]},
         {"id": "2300","transformation": { "func": "DIRECT", "params": { "field": "port_industr"}}},

--- a/export/config/current/sheet_configs/config_fognat_tronchi.json
+++ b/export/config/current/sheet_configs/config_fognat_tronchi.json
@@ -54,7 +54,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is not 0"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not 0"
                 }
             ]},
       {"id": "61700","transformation": { "func": "DIRECT", "params": { "field": "diametro"}}, "validations": [{
@@ -68,7 +68,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is greater than 2002 or is None"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is greater than 2002 or is None"
                 }
             ]},
       {"id": "61500","transformation": { "func": "DOMAIN", "params": { "field": "d_materiale", "domain_name":  "D_MATERIALE_IDR"}}, "validations": [{
@@ -82,7 +82,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is greater than 2014 or is None"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is greater than 2014 or is None"
                 }
             ]},
       {"id": "61600","transformation": { "func": "DOMAIN", "params": { "field": "d_stato_cons", "domain_name":  "D_STATO_CONS"}}},
@@ -108,7 +108,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: field is lower than the ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is lower than the ref_year"
                 }
             ]
       },

--- a/export/config/current/sheet_configs/config_fognat_tronchi.json
+++ b/export/config/current/sheet_configs/config_fognat_tronchi.json
@@ -54,7 +54,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not 0"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is not 0"
                 }
             ]},
       {"id": "61700","transformation": { "func": "DIRECT", "params": { "field": "diametro"}}, "validations": [{
@@ -68,7 +68,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is greater than 2002 or is None"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is greater than 2002 or is None"
                 }
             ]},
       {"id": "61500","transformation": { "func": "DOMAIN", "params": { "field": "d_materiale", "domain_name":  "D_MATERIALE_IDR"}}, "validations": [{
@@ -82,7 +82,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is greater than 2014 or is None"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is greater than 2014 or is None"
                 }
             ]},
       {"id": "61600","transformation": { "func": "DOMAIN", "params": { "field": "d_stato_cons", "domain_name":  "D_STATO_CONS"}}},
@@ -108,7 +108,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is lower than the ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: field is lower than the {REF_YEAR}"
                 }
             ]
       },

--- a/export/config/current/sheet_configs/config_fognat_tronchi.json
+++ b/export/config/current/sheet_configs/config_fognat_tronchi.json
@@ -102,7 +102,7 @@
                     "params": {
                         "field": "61800",
                         "cond": [{
-                            "and": [
+                            "or": [
                               {"operator": "<=", "value": "{REF_YEAR}"},
                               {"operator":  "=", "value": 9999}
                             ]

--- a/export/config/current/sheet_configs/config_fognature.json
+++ b/export/config/current/sheet_configs/config_fognature.json
@@ -179,7 +179,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is not 0"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not 0"
                 }
             ]},
         {"id": "60300","transformation": { "func": "DIRECT", "params": { "field": "sn_strum_mis_port"}}},

--- a/export/config/current/sheet_configs/config_fognature.json
+++ b/export/config/current/sheet_configs/config_fognature.json
@@ -179,7 +179,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not 0"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is not 0"
                 }
             ]},
         {"id": "60300","transformation": { "func": "DIRECT", "params": { "field": "sn_strum_mis_port"}}},

--- a/export/config/current/sheet_configs/config_laghi.json
+++ b/export/config/current/sheet_configs/config_laghi.json
@@ -231,7 +231,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is 0"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is 0"
                 }
             ]},
         {"id": "8800","transformation": { "func": "DIRECT", "params": { "field": "bacino" }}},
@@ -247,7 +247,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: field is not greater than 10500"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is not greater than 10500"
                 }
             ]},
         {"id": "9300","transformation": { "func": "DIRECT", "params": { "field": "port_industr" }}},
@@ -265,7 +265,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Value is minor of the ref_year and is not 9999"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is minor of the ref_year and is not 9999"
                 }
             ]},
         {"id": "9800","transformation": { "func": "DIRECT", "params": { "field": "anno_ristr" }},"validations": [{
@@ -279,7 +279,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Value is minor of the ref_year and is not 9999"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is minor of the ref_year and is not 9999"
                 }
             ]},
         {"id": "10100","transformation": { "func": "DIRECT", "params": { "field": "utilizzo_annuo" }}, "validations": [{
@@ -303,7 +303,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: field is not continuo or occasionale"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is not continuo or occasionale"
                 }
             ]},
         {"id": "10200","transformation": { "func": "DIRECT", "params": { "field": "area_bac_affer" }}},
@@ -323,7 +323,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: field is not valid"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is not valid"
                 }
             ]},
         {"id": "10600","transformation": { "func": "DIRECT", "params": { "field": "port_uti_max" }}, "validations": [{
@@ -342,7 +342,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: field is not valid"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is not valid"
                 }
             ]},
         {"id": "10700","transformation": { "func": "DIRECT", "params": { "field": "port_uti_min" }},"validations": [{
@@ -361,7 +361,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: field is not valid"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is not valid"
                 }
             ]},
         {"id": "10800","transformation": { "func": "DIRECT", "params": { "field": "port_deriv" }}},
@@ -386,7 +386,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: field error"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field error"
                 }
             ]},
         {"id": "11900","transformation": { "func": "DIRECT", "params": { "field": "anno_ristr_clor" }},"validations": [{
@@ -405,7 +405,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: field field error"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field field error"
                 }
             ]},
         {"id": "13000","transformation": { "func": "DIRECT", "params": { "field": "data_agg" }}},
@@ -420,7 +420,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is not lower than the field 9200"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not lower than the field 9200"
                 }
             ]},
 
@@ -436,7 +436,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is lower than 3"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is lower than 3"
                 }
             ]},
         {"id": "10000","transformation": { "func": "DOMAIN", "params": { "field": "d_utilizzo", "domain_name": "D_UTILIZZO_OPERA" }}, "validations": [{
@@ -456,7 +456,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: field is not continuo or occasionale"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is not continuo or occasionale"
                 }
             ]},
         {"id": "11200","transformation": { "func": "DOMAIN", "params": { "field": "d_telecont", "domain_name": "D_TELECONT" }}},
@@ -471,7 +471,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: field is 1"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is 1"
                 }
             ]},
         {"id": "12000","transformation": { "func": "DOMAIN", "params": { "field": "d_stato", "domain_name": "D_STATO" }}},
@@ -493,7 +493,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: field is not A or X"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is not A or X"
                 }
             ]},
         {"id": "12300","transformation": { "func": "DOMAIN", "params": { "field": "a_anno_ristr", "domain_name":  "D_AFFIDABILITA" }},"validations": [{
@@ -507,7 +507,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: field is not A"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is not A"
                 }
             ]},
         {"id": "12400","transformation": { "func": "DOMAIN", "params": { "field": "a_volume", "domain_name":  "D_AFFIDABILITA" }},"validations": [{
@@ -533,7 +533,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: One or more condition are failing"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: One or more condition are failing"
                 }
             ]},
         {"id": "12600","transformation": { "func": "DOMAIN", "params": { "field": "a_port_es", "domain_name":  "D_AFFIDABILITA" }},"validations": [{
@@ -546,7 +546,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: field is not equal to ID 12400"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is not equal to ID 12400"
                 }
             ]},
         {"id": "12700","transformation": { "func": "DOMAIN", "params": { "field": "a_port_uti_max", "domain_name":  "D_AFFIDABILITA" }},"validations": [{
@@ -572,7 +572,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: One or more condition are failing"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: One or more condition are failing"
                 }
             ]},
         {"id": "12800","transformation": { "func": "DOMAIN", "params": { "field": "a_port_uti_min", "domain_name":  "D_AFFIDABILITA" }},"validations": [{
@@ -598,7 +598,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: One or more condition are failing"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: One or more condition are failing"
                 }
             ]},
         {"id": "12900","transformation": { "func": "DOMAIN", "params": { "field": "a_port_deriv", "domain_name":  "D_AFFIDABILITA" }}},

--- a/export/config/current/sheet_configs/config_laghi.json
+++ b/export/config/current/sheet_configs/config_laghi.json
@@ -260,8 +260,8 @@
                         "field": "9700",
                         "cond": [{
                             "or": [
-                              {"operator": ">=", "value": "{REF_YEAR}"},
-                              {"operator": "!=", "value": 9999}
+                              {"operator": "<=", "value": "{REF_YEAR}"},
+                              {"operator": "=", "value": 9999}
                             ]
                         }]
                     },
@@ -274,8 +274,8 @@
                         "field": "9800",
                         "cond": [{
                             "or": [
-                              {"operator": ">=", "value": "{REF_YEAR}"},
-                              {"operator": "!=", "value": 9800}
+                              {"operator": "<=", "value": "{REF_YEAR}"},
+                              {"operator": "=", "value": 9800}
                             ]
                         }]
                     },
@@ -381,8 +381,8 @@
                             ]
                         },{
                             "or": [
-                              {"operator": ">", "value": "{REF_YEAR}"},
-                              {"operator": "!=", "value": 9999}
+                              {"operator": "<", "value": "{REF_YEAR}"},
+                              {"operator": "=", "value": 9999}
                             ]
                         }]
                     },
@@ -400,8 +400,8 @@
                             ]
                         },{
                             "or": [
-                              {"operator": ">", "value": "{REF_YEAR}"},
-                              {"operator": "!=", "value": 9800}
+                              {"operator": "<", "value": "{REF_YEAR}"},
+                              {"operator": "=", "value": 9800}
                             ]
                         }]
                     },

--- a/export/config/current/sheet_configs/config_laghi.json
+++ b/export/config/current/sheet_configs/config_laghi.json
@@ -231,7 +231,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is 0"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is 0"
                 }
             ]},
         {"id": "8800","transformation": { "func": "DIRECT", "params": { "field": "bacino" }}},
@@ -247,7 +247,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is not greater than 10500"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: field is not greater than 10500"
                 }
             ]},
         {"id": "9300","transformation": { "func": "DIRECT", "params": { "field": "port_industr" }}},
@@ -265,7 +265,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is minor of the ref_year and is not 9999"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Value is minor of the {REF_YEAR} and is not 9999"
                 }
             ]},
         {"id": "9800","transformation": { "func": "DIRECT", "params": { "field": "anno_ristr" }},"validations": [{
@@ -279,7 +279,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is minor of the ref_year and is not 9999"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Value is minor of the {REF_YEAR} and is not 9999"
                 }
             ]},
         {"id": "10100","transformation": { "func": "DIRECT", "params": { "field": "utilizzo_annuo" }}, "validations": [{
@@ -303,7 +303,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is not continuo or occasionale"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: field is not continuo or occasionale"
                 }
             ]},
         {"id": "10200","transformation": { "func": "DIRECT", "params": { "field": "area_bac_affer" }}},
@@ -323,7 +323,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is not valid"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: field is not valid"
                 }
             ]},
         {"id": "10600","transformation": { "func": "DIRECT", "params": { "field": "port_uti_max" }}, "validations": [{
@@ -342,7 +342,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is not valid"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: field is not valid"
                 }
             ]},
         {"id": "10700","transformation": { "func": "DIRECT", "params": { "field": "port_uti_min" }},"validations": [{
@@ -361,7 +361,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is not valid"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: field is not valid"
                 }
             ]},
         {"id": "10800","transformation": { "func": "DIRECT", "params": { "field": "port_deriv" }}},
@@ -386,7 +386,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field error"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: field error"
                 }
             ]},
         {"id": "11900","transformation": { "func": "DIRECT", "params": { "field": "anno_ristr_clor" }},"validations": [{
@@ -405,7 +405,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field field error"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: field field error"
                 }
             ]},
         {"id": "13000","transformation": { "func": "DIRECT", "params": { "field": "data_agg" }}},
@@ -420,7 +420,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not lower than the field 9200"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is not lower than the field 9200"
                 }
             ]},
 
@@ -436,7 +436,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is lower than 3"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is lower than 3"
                 }
             ]},
         {"id": "10000","transformation": { "func": "DOMAIN", "params": { "field": "d_utilizzo", "domain_name": "D_UTILIZZO_OPERA" }}, "validations": [{
@@ -456,7 +456,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is not continuo or occasionale"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: field is not continuo or occasionale"
                 }
             ]},
         {"id": "11200","transformation": { "func": "DOMAIN", "params": { "field": "d_telecont", "domain_name": "D_TELECONT" }}},
@@ -471,7 +471,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is 1"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: field is 1"
                 }
             ]},
         {"id": "12000","transformation": { "func": "DOMAIN", "params": { "field": "d_stato", "domain_name": "D_STATO" }}},
@@ -493,7 +493,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is not A or X"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: field is not A or X"
                 }
             ]},
         {"id": "12300","transformation": { "func": "DOMAIN", "params": { "field": "a_anno_ristr", "domain_name":  "D_AFFIDABILITA" }},"validations": [{
@@ -507,7 +507,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is not A"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: field is not A"
                 }
             ]},
         {"id": "12400","transformation": { "func": "DOMAIN", "params": { "field": "a_volume", "domain_name":  "D_AFFIDABILITA" }},"validations": [{
@@ -533,7 +533,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: One or more condition are failing"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: One or more condition are failing"
                 }
             ]},
         {"id": "12600","transformation": { "func": "DOMAIN", "params": { "field": "a_port_es", "domain_name":  "D_AFFIDABILITA" }},"validations": [{
@@ -546,7 +546,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is not equal to ID 12400"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: field is not equal to ID 12400"
                 }
             ]},
         {"id": "12700","transformation": { "func": "DOMAIN", "params": { "field": "a_port_uti_max", "domain_name":  "D_AFFIDABILITA" }},"validations": [{
@@ -572,7 +572,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: One or more condition are failing"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: One or more condition are failing"
                 }
             ]},
         {"id": "12800","transformation": { "func": "DOMAIN", "params": { "field": "a_port_uti_min", "domain_name":  "D_AFFIDABILITA" }},"validations": [{
@@ -598,7 +598,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: One or more condition are failing"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: One or more condition are failing"
                 }
             ]},
         {"id": "12900","transformation": { "func": "DOMAIN", "params": { "field": "a_port_deriv", "domain_name":  "D_AFFIDABILITA" }}},

--- a/export/config/current/sheet_configs/config_pompaggi.json
+++ b/export/config/current/sheet_configs/config_pompaggi.json
@@ -154,7 +154,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is 0"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is 0"
                 }
             ]},
         {"id": "48700","transformation": { "func": "DIRECT", "params": { "field": "anno_costr" }}, "validations": [{
@@ -168,7 +168,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field greater than ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field greater than {REF_YEAR}"
                 }
             ]},
         {"id": "48800","transformation": { "func": "DIRECT", "params": { "field": "anno_ristr_civ" }}, "validations": [{
@@ -182,7 +182,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field greater than ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field greater than {REF_YEAR}"
                 }
             ]},
         {"id": "49000","transformation": { "func": "DIRECT", "params": { "field": "anno_ristr_elmec" }}, "validations": [{
@@ -196,7 +196,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field greater than ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field greater than {REF_YEAR}"
                 }
             ]},
         {"id": "49500","transformation": { "func": "DIRECT", "params": { "field": "sn_strum_mis_pres" }}},
@@ -214,7 +214,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is lower than 0"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is lower than 0"
                 }
             ]},
 
@@ -244,7 +244,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is lower than 3"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is lower than 3"
                 }
             ]},
         {"id": "49100","transformation": { "func": "DOMAIN", "params": { "field": "d_stato_cons_elmec", "domain_name": "D_STATO_CONS" }}, "validations": [{
@@ -258,7 +258,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is lower than 3 and year must be greater than 2014"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is lower than 3 and year must be greater than 2014"
                 }
             ]},
         {"id": "49400","transformation": { "func": "DOMAIN", "params": { "field": "d_telecont", "domain_name": "D_TELECONT" }}},
@@ -280,7 +280,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not X or A"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is not X or A"
                 }
             ]},
         {"id": "49900","transformation": { "func": "DOMAIN", "params": { "field": "a_anno_ristr_civ", "domain_name":  "D_AFFIDABILITA" }}, "validations": [{
@@ -294,7 +294,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not A"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is not A"
                 }
             ]},
         {"id": "50000","transformation": { "func": "DOMAIN", "params": { "field": "a_anno_ristr_elmec", "domain_name":  "D_AFFIDABILITA" }}, "validations": [{
@@ -308,7 +308,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not A"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is not A"
                 }
             ]}
     ]

--- a/export/config/current/sheet_configs/config_pompaggi.json
+++ b/export/config/current/sheet_configs/config_pompaggi.json
@@ -154,7 +154,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is 0"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is 0"
                 }
             ]},
         {"id": "48700","transformation": { "func": "DIRECT", "params": { "field": "anno_costr" }}, "validations": [{
@@ -168,7 +168,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field greater than ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field greater than ref_year"
                 }
             ]},
         {"id": "48800","transformation": { "func": "DIRECT", "params": { "field": "anno_ristr_civ" }}, "validations": [{
@@ -182,7 +182,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field greater than ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field greater than ref_year"
                 }
             ]},
         {"id": "49000","transformation": { "func": "DIRECT", "params": { "field": "anno_ristr_elmec" }}, "validations": [{
@@ -196,7 +196,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field greater than ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field greater than ref_year"
                 }
             ]},
         {"id": "49500","transformation": { "func": "DIRECT", "params": { "field": "sn_strum_mis_pres" }}},
@@ -214,7 +214,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is lower than 0"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is lower than 0"
                 }
             ]},
 
@@ -244,7 +244,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is lower than 3"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is lower than 3"
                 }
             ]},
         {"id": "49100","transformation": { "func": "DOMAIN", "params": { "field": "d_stato_cons_elmec", "domain_name": "D_STATO_CONS" }}, "validations": [{
@@ -258,7 +258,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is lower than 3 and year must be greater than 2014"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is lower than 3 and year must be greater than 2014"
                 }
             ]},
         {"id": "49400","transformation": { "func": "DOMAIN", "params": { "field": "d_telecont", "domain_name": "D_TELECONT" }}},
@@ -280,7 +280,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is not X or A"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not X or A"
                 }
             ]},
         {"id": "49900","transformation": { "func": "DOMAIN", "params": { "field": "a_anno_ristr_civ", "domain_name":  "D_AFFIDABILITA" }}, "validations": [{
@@ -294,7 +294,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is not A"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not A"
                 }
             ]},
         {"id": "50000","transformation": { "func": "DOMAIN", "params": { "field": "a_anno_ristr_elmec", "domain_name":  "D_AFFIDABILITA" }}, "validations": [{
@@ -308,7 +308,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is not A"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not A"
                 }
             ]}
     ]

--- a/export/config/current/sheet_configs/config_pompaggi.json
+++ b/export/config/current/sheet_configs/config_pompaggi.json
@@ -163,8 +163,8 @@
                         "field": "48700",
                         "cond": [{
                             "or": [
-                              {"operator": ">=", "value": "{REF_YEAR}"},
-                              {"operator":  "!=", "value": 9999}
+                              {"operator": "<=", "value": "{REF_YEAR}"},
+                              {"operator": "=", "value": 9999}
                             ]
                         }]
                     },
@@ -177,8 +177,8 @@
                         "field": "48800",
                         "cond": [{
                             "or": [
-                              {"operator": ">=", "value": "{REF_YEAR}"},
-                              {"operator":  "!=", "value": 9800}
+                              {"operator": "<=", "value": "{REF_YEAR}"},
+                              {"operator":  "=", "value": 9800}
                             ]
                         }]
                     },
@@ -191,8 +191,8 @@
                         "field": "49000",
                         "cond": [{
                             "or": [
-                              {"operator": ">=", "value": "{REF_YEAR}"},
-                              {"operator":  "!=", "value": 9800}
+                              {"operator": "<=", "value": "{REF_YEAR}"},
+                              {"operator":  "=", "value": 9800}
                             ]
                         }]
                     },

--- a/export/config/current/sheet_configs/config_pompaggi_pompe.json
+++ b/export/config/current/sheet_configs/config_pompaggi_pompe.json
@@ -38,7 +38,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is greater than ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is greater than ref_year"
                 }
             ]},
         {"id": "50900","transformation": { "func": "DIRECT", "params": { "field": "anno_ristr" }}, "validations": [{
@@ -52,7 +52,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is greater than ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is greater than ref_year"
                 }
             ]},
         {"id": "51000","transformation": { "func": "DIRECT", "params": { "field": "potenza" }}},
@@ -75,7 +75,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: field is not A or X"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is not A or X"
                 }
             ]},
         {"id": "51500","transformation": { "func": "DOMAIN", "params": { "field": "a_anno_ristr", "domain_name":  "D_AFFIDABILITA" }},"validations": [{
@@ -89,7 +89,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is greater than ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is greater than ref_year"
                 }
             ]},
         {"id": "51600","transformation": { "func": "DIRECT", "params": { "field": "a_potenza" }}},

--- a/export/config/current/sheet_configs/config_pompaggi_pompe.json
+++ b/export/config/current/sheet_configs/config_pompaggi_pompe.json
@@ -32,9 +32,9 @@
                     "params": {
                         "field": "50800",
                         "cond": [{
-                            "and": [
-                              {"operator": ">=", "value": "{REF_YEAR}"},
-                              {"operator":  "!=", "value": 9999}
+                            "or": [
+                              {"operator": "<=", "value": "{REF_YEAR}"},
+                              {"operator":  "=", "value": 9999}
                             ]
                         }]
                     },
@@ -46,9 +46,9 @@
                     "params": {
                         "field": "50900",
                         "cond": [{
-                            "and": [
-                              {"operator": ">=", "value": "{REF_YEAR}"},
-                              {"operator":  "!=", "value": 9800}
+                            "or": [
+                              {"operator": "<=", "value": "{REF_YEAR}"},
+                              {"operator":  "=", "value": 9800}
                             ]
                         }]
                     },

--- a/export/config/current/sheet_configs/config_pompaggi_pompe.json
+++ b/export/config/current/sheet_configs/config_pompaggi_pompe.json
@@ -38,7 +38,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is greater than ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is greater than {REF_YEAR}"
                 }
             ]},
         {"id": "50900","transformation": { "func": "DIRECT", "params": { "field": "anno_ristr" }}, "validations": [{
@@ -52,7 +52,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is greater than ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is greater than {REF_YEAR}"
                 }
             ]},
         {"id": "51000","transformation": { "func": "DIRECT", "params": { "field": "potenza" }}},
@@ -75,7 +75,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is not A or X"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: field is not A or X"
                 }
             ]},
         {"id": "51500","transformation": { "func": "DOMAIN", "params": { "field": "a_anno_ristr", "domain_name":  "D_AFFIDABILITA" }},"validations": [{
@@ -89,7 +89,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is greater than ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is greater than {REF_YEAR}"
                 }
             ]},
         {"id": "51600","transformation": { "func": "DIRECT", "params": { "field": "a_potenza" }}},

--- a/export/config/current/sheet_configs/config_potab_pompe.json
+++ b/export/config/current/sheet_configs/config_potab_pompe.json
@@ -46,8 +46,8 @@
                         "field": "37300",
                         "cond": [{
                             "or": [
-                              {"operator": ">=", "value": "{REF_YEAR}"},
-                              {"operator":  "!=", "value": 9999}
+                              {"operator": "<=", "value": "{REF_YEAR}"},
+                              {"operator":  "=", "value": 9999}
                             ]
                         }]
                     },
@@ -60,8 +60,8 @@
                         "field": "37400",
                         "cond": [{
                             "or": [
-                              {"operator": ">=", "value": "{REF_YEAR}"},
-                              {"operator":  "!=", "value": 9800}
+                              {"operator": "<=", "value": "{REF_YEAR}"},
+                              {"operator":  "=", "value": 9800}
                             ]
                         }]
                     },

--- a/export/config/current/sheet_configs/config_potab_pompe.json
+++ b/export/config/current/sheet_configs/config_potab_pompe.json
@@ -37,7 +37,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is lower than 3"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is lower than 3"
                 }
             ]},
         {"id": "37300","transformation": { "func": "DIRECT", "params": { "field": "anno_instal" }},  "validations": [{
@@ -51,7 +51,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field greater than ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field greater than {REF_YEAR}"
                 }
             ]},
         {"id": "37400","transformation": { "func": "DIRECT", "params": { "field": "anno_ristr" }},  "validations": [{
@@ -65,7 +65,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field greater than ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field greater than {REF_YEAR}"
                 }
             ]},
         {"id": "37500","transformation": { "func": "DIRECT", "params": { "field": "potenza" }}},
@@ -82,7 +82,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not A"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is not A"
                 }
             ]},
         {"id": "37900","transformation": { "func": "DIRECT", "params": { "field": "a_anno_instal"}}, "validations": [{
@@ -101,7 +101,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not X or A"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is not X or A"
                 }
             ]},
         {"id": "38000","transformation": { "func": "DIRECT", "params": { "field": "a_anno_ristr"}}},

--- a/export/config/current/sheet_configs/config_potab_pompe.json
+++ b/export/config/current/sheet_configs/config_potab_pompe.json
@@ -37,7 +37,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is lower than 3"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is lower than 3"
                 }
             ]},
         {"id": "37300","transformation": { "func": "DIRECT", "params": { "field": "anno_instal" }},  "validations": [{
@@ -51,7 +51,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field greater than ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field greater than ref_year"
                 }
             ]},
         {"id": "37400","transformation": { "func": "DIRECT", "params": { "field": "anno_ristr" }},  "validations": [{
@@ -65,7 +65,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field greater than ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field greater than ref_year"
                 }
             ]},
         {"id": "37500","transformation": { "func": "DIRECT", "params": { "field": "potenza" }}},
@@ -82,7 +82,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is not A"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not A"
                 }
             ]},
         {"id": "37900","transformation": { "func": "DIRECT", "params": { "field": "a_anno_instal"}}, "validations": [{
@@ -101,7 +101,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is not X or A"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not X or A"
                 }
             ]},
         {"id": "38000","transformation": { "func": "DIRECT", "params": { "field": "a_anno_ristr"}}},

--- a/export/config/current/sheet_configs/config_potabilizzatori.json
+++ b/export/config/current/sheet_configs/config_potabilizzatori.json
@@ -196,7 +196,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is 0"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is 0"
                 }
             ]},
       {"id":"31800", "transformation":{"func":"DIRECT", "params":{"field":"anno_costr"}}, "validations": [{
@@ -210,7 +210,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field greater than ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field greater than ref_year"
                 }
             ]},
       {"id":"32100", "transformation":{"func":"DIRECT", "params":{"field":"vol_gg_trattabile"}}},
@@ -225,7 +225,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: value in lower than 0"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: value in lower than 0"
                 }
             ]},
       {"id":"36100", "transformation":{"func":"DIRECT", "params":{"field":"data_agg"}}},
@@ -240,7 +240,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field greater than ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field greater than ref_year"
                 }
             ]},
       {"id":"32030", "transformation":{"func":"DIRECT", "params":{"field":"anno_ristr_elmec"}}, "validations": [{
@@ -254,7 +254,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field greater than ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field greater than ref_year"
                 }
             ]},
       {"id":"32300", "transformation":{"func":"DIRECT", "params":{"field":"potenza_instal"}}},
@@ -296,7 +296,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is not greater than 0"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not greater than 0"
                 }
             ]},
       {"id":"31500", "transformation":{"func":"DIRECT", "params":{"field":"denominazi"}}},
@@ -319,7 +319,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is lower than 3"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is lower than 3"
                 }
             ]},
       {"id":"32040", "transformation":{"func":"DOMAIN", "params":{"field":"d_stato_cons_elmec", "domain_name": "D_STATO_CONS"}}, "validations": [{
@@ -333,7 +333,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is lower than 3"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is lower than 3"
                 }
             ]},
       {"id":"32700", "transformation":{"func":"DOMAIN", "params":{"field":"d_telecont", "domain_name": "D_TELECONT"}}},
@@ -364,7 +364,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: value is not A or X"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: value is not A or X"
                 }
             ]},
       {"id":"35710", "transformation":{"func":"DOMAIN", "params":{"field":"a_anno_ristr_civ", "domain_name": "D_AFFIDABILITA"}}},
@@ -391,7 +391,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: value is not A or C"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: value is not A or C"
                 }
             ]},
       {"id":"98700", "transformation":{"func":"DOMAIN", "params":{"field":"a_vol_uscita", "domain_name": "D_AFFIDABILITA"}}, "validations": [{
@@ -417,7 +417,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: value is not A or C"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: value is not A or C"
                 }
             ]},
       {"id":"35720", "transformation":{"func":"DOMAIN", "params":{"field":"a_anno_ristr_elmec", "domain_name": "D_AFFIDABILITA"}}, "validations": [{
@@ -431,7 +431,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: value is not AC"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: value is not AC"
                 }
             ]},
 

--- a/export/config/current/sheet_configs/config_potabilizzatori.json
+++ b/export/config/current/sheet_configs/config_potabilizzatori.json
@@ -196,7 +196,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is 0"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is 0"
                 }
             ]},
       {"id":"31800", "transformation":{"func":"DIRECT", "params":{"field":"anno_costr"}}, "validations": [{
@@ -210,7 +210,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field greater than ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field greater than {REF_YEAR}"
                 }
             ]},
       {"id":"32100", "transformation":{"func":"DIRECT", "params":{"field":"vol_gg_trattabile"}}},
@@ -225,7 +225,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: value in lower than 0"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: value in lower than 0"
                 }
             ]},
       {"id":"36100", "transformation":{"func":"DIRECT", "params":{"field":"data_agg"}}},
@@ -240,7 +240,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field greater than ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field greater than {REF_YEAR}"
                 }
             ]},
       {"id":"32030", "transformation":{"func":"DIRECT", "params":{"field":"anno_ristr_elmec"}}, "validations": [{
@@ -254,7 +254,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field greater than ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field greater than {REF_YEAR}"
                 }
             ]},
       {"id":"32300", "transformation":{"func":"DIRECT", "params":{"field":"potenza_instal"}}},
@@ -296,7 +296,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not greater than 0"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is not greater than 0"
                 }
             ]},
       {"id":"31500", "transformation":{"func":"DIRECT", "params":{"field":"denominazi"}}},
@@ -319,7 +319,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is lower than 3"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is lower than 3"
                 }
             ]},
       {"id":"32040", "transformation":{"func":"DOMAIN", "params":{"field":"d_stato_cons_elmec", "domain_name": "D_STATO_CONS"}}, "validations": [{
@@ -333,7 +333,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is lower than 3"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is lower than 3"
                 }
             ]},
       {"id":"32700", "transformation":{"func":"DOMAIN", "params":{"field":"d_telecont", "domain_name": "D_TELECONT"}}},
@@ -364,7 +364,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: value is not A or X"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: value is not A or X"
                 }
             ]},
       {"id":"35710", "transformation":{"func":"DOMAIN", "params":{"field":"a_anno_ristr_civ", "domain_name": "D_AFFIDABILITA"}}},
@@ -391,7 +391,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: value is not A or C"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: value is not A or C"
                 }
             ]},
       {"id":"98700", "transformation":{"func":"DOMAIN", "params":{"field":"a_vol_uscita", "domain_name": "D_AFFIDABILITA"}}, "validations": [{
@@ -417,7 +417,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: value is not A or C"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: value is not A or C"
                 }
             ]},
       {"id":"35720", "transformation":{"func":"DOMAIN", "params":{"field":"a_anno_ristr_elmec", "domain_name": "D_AFFIDABILITA"}}, "validations": [{
@@ -431,7 +431,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: value is not AC"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: value is not AC"
                 }
             ]},
 

--- a/export/config/current/sheet_configs/config_potabilizzatori.json
+++ b/export/config/current/sheet_configs/config_potabilizzatori.json
@@ -205,8 +205,8 @@
                         "field": "31800",
                         "cond": [{
                             "or": [
-                              {"operator": ">=", "value": "{REF_YEAR}"},
-                              {"operator":  "!=", "value": 9999}
+                              {"operator": "<=", "value": "{REF_YEAR}"},
+                              {"operator":  "=", "value": 9999}
                             ]
                         }]
                     },
@@ -235,8 +235,8 @@
                         "field": "32010",
                         "cond": [{
                             "or": [
-                              {"operator": ">=", "value": "{REF_YEAR}"},
-                              {"operator":  "!=", "value": 9800}
+                              {"operator": "<=", "value": "{REF_YEAR}"},
+                              {"operator":  "=", "value": 9800}
                             ]
                         }]
                     },
@@ -249,8 +249,8 @@
                         "field": "32030",
                         "cond": [{
                             "or": [
-                              {"operator": ">=", "value": "{REF_YEAR}"},
-                              {"operator":  "!=", "value": 9800}
+                              {"operator": "<=", "value": "{REF_YEAR}"},
+                              {"operator":  "=", "value": 9800}
                             ]
                         }]
                     },

--- a/export/config/current/sheet_configs/config_pozzi.json
+++ b/export/config/current/sheet_configs/config_pozzi.json
@@ -232,7 +232,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field not lower than ID 15600"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field not lower than ID 15600"
           }
       ]},
 
@@ -250,7 +250,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: value is not 0"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: value is not 0"
                 }
             ]},
       {"id":"15500", "transformation":{"func":"DIRECT", "params":{"field":"estremi_conces"}}},
@@ -264,7 +264,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Value is lower than the value in field 17200"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is lower than the value in field 17200"
           }
       ]},
       {"id":"15700", "transformation":{"func":"DIRECT", "params":{"field":"port_industr"}}},
@@ -282,7 +282,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Value is not valid for the ref_year selected"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, {custom:port_altro}, Campo: {FIELD}: Value is not valid for year ref_year"
           }
       ]},
       {"id":"16200", "transformation":{"func":"DIRECT", "params":{"field":"anno_ristr"}}, "validations": [{
@@ -296,7 +296,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Value is not valid for the ref_year selected"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is not valid for year ref_year"
           }
       ]},
       {"id":"16500", "transformation":{"func":"DIRECT", "params":{"field":"utilizzo_annuo"}}, "validations": [{
@@ -320,7 +320,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Value is lower than 3"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is lower than 3"
           }
       ]},
       {"id":"16600", "transformation":{"func":"DIRECT", "params":{"field":"prof_pozzo"}}},
@@ -341,7 +341,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is lower than 0"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is lower than 0"
           }
       ]},
       {"id":"17300", "transformation":{"func":"DIRECT", "params":{"field":"port_uti_max"}}},
@@ -361,7 +361,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field not lower than ID 15600"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field not lower than ID 15600"
           }
       ]},
       {"id":"17600", "transformation":{"func":"DIRECT", "params":{"field":"sn_strum_mis_port"}}},
@@ -381,7 +381,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Value 1 is not permitted or ref_year"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value 1 is not permitted or ref_year"
           }
       ]},
       {"id":"18300", "transformation":{"func":"DIRECT", "params":{"field":"anno_ristr_clor"}}, "validations": [{
@@ -400,7 +400,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Value 1 is not permitted or ref_year"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value 1 is not permitted or ref_year"
           }
       ]},
       {"id":"18400", "transformation":{"func":"DIRECT", "params":{"field":"sn_epis_inq"}}},
@@ -420,7 +420,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Value is lower than 3"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is lower than 3"
           }
       ]},
       {"id":"16400", "transformation":{"func":"DOMAIN", "params":{"field":"d_utilizzo", "domain_name": "D_UTILIZZO_OPERA"}}, "validations": [{
@@ -440,7 +440,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Value is lower than 3"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is lower than 3"
           }
       ]},
       {"id":"17500", "transformation":{"func":"DOMAIN", "params":{"field":"d_telecont", "domain_name": "D_TELECONT"}}},
@@ -455,7 +455,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Value 1 is not permitted"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value 1 is not permitted"
           }
       ]},
       {"id":"18500", "transformation":{"func":"DOMAIN", "params":{"field":"d_stato", "domain_name": "D_STATO"}}},
@@ -476,7 +476,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Value is not A or X"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is not A or X"
           }
       ]},
       {"id":"18700", "transformation":{"func":"DOMAIN", "params":{"field":"a_anno_ristr", "domain_name": "D_AFFIDABILITA"}}, "validations": [{
@@ -490,7 +490,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Value is not A"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is not A"
           }
       ]},
       {"id":"18900", "transformation":{"func":"DOMAIN", "params":{"field":"a_volume", "domain_name": "D_AFFIDABILITA"}}, "validations": [{
@@ -515,7 +515,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Value is not A or C"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is not A or C"
           }
       ]},
       {"id":"19100", "transformation":{"func":"DOMAIN", "params":{"field":"a_port_es", "domain_name": "D_AFFIDABILITA"}}, "validations": [{
@@ -528,7 +528,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Value is not A or C"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is not A or C"
           }
       ]},
       {"id":"19200", "transformation":{"func":"DOMAIN", "params":{"field":"a_port_uti_max", "domain_name": "D_AFFIDABILITA"}}, "validations": [{
@@ -554,7 +554,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Value is not A or C"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is not A or C"
           }
       ]},
       {"id":"19300", "transformation":{"func":"DOMAIN", "params":{"field":"a_port_uti_min", "domain_name": "D_AFFIDABILITA"}}, "validations": [{
@@ -580,7 +580,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Value is not A or C"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is not A or C"
           }
       ]},
 

--- a/export/config/current/sheet_configs/config_pozzi.json
+++ b/export/config/current/sheet_configs/config_pozzi.json
@@ -232,7 +232,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field not lower than ID 15600"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field not lower than ID 15600"
           }
       ]},
 
@@ -250,7 +250,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: value is not 0"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: value is not 0"
                 }
             ]},
       {"id":"15500", "transformation":{"func":"DIRECT", "params":{"field":"estremi_conces"}}},
@@ -264,7 +264,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is lower than the value in field 17200"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Value is lower than the value in field 17200"
           }
       ]},
       {"id":"15700", "transformation":{"func":"DIRECT", "params":{"field":"port_industr"}}},
@@ -276,13 +276,13 @@
               "params": {
                   "field": "16100",
                   "cond": [{
-                      "and": [
+                      "or": [
                         {"operator": "<=", "value": "{REF_YEAR}"},
-                        {"operator": "!=", "value": 9999}
+                        {"operator": "=", "value": 9999}
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET}, Riga:{ROW}, {custom:port_altro}, Campo: {FIELD}: Value is not valid for year ref_year"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Value is not valid for year {REF_YEAR}"
           }
       ]},
       {"id":"16200", "transformation":{"func":"DIRECT", "params":{"field":"anno_ristr"}}, "validations": [{
@@ -290,13 +290,13 @@
               "params": {
                   "field": "16200",
                   "cond": [{
-                      "and": [
+                      "or": [
                         {"operator": "<=", "value": "{REF_YEAR}"},
-                        {"operator": "!=", "value": 9800}
+                        {"operator": "=", "value": 9800}
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is not valid for year ref_year"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Value is not valid for year {REF_YEAR}"
           }
       ]},
       {"id":"16500", "transformation":{"func":"DIRECT", "params":{"field":"utilizzo_annuo"}}, "validations": [{
@@ -320,7 +320,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is lower than 3"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Value is lower than 3"
           }
       ]},
       {"id":"16600", "transformation":{"func":"DIRECT", "params":{"field":"prof_pozzo"}}},
@@ -341,7 +341,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is lower than 0"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is lower than 0"
           }
       ]},
       {"id":"17300", "transformation":{"func":"DIRECT", "params":{"field":"port_uti_max"}}},
@@ -361,7 +361,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field not lower than ID 15600"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field not lower than ID 15600"
           }
       ]},
       {"id":"17600", "transformation":{"func":"DIRECT", "params":{"field":"sn_strum_mis_port"}}},
@@ -375,13 +375,13 @@
                         {"operator": "=", "value": 9800}
                       ]
                   },{
-                      "and": [
+                      "or": [
                         {"operator": "<=", "value": "{REF_YEAR}"},
-                        {"operator": "!=", "value": 9999}
+                        {"operator": "=", "value": 9999}
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value 1 is not permitted or ref_year"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Value 1 is not permitted or {REF_YEAR}"
           }
       ]},
       {"id":"18300", "transformation":{"func":"DIRECT", "params":{"field":"anno_ristr_clor"}}, "validations": [{
@@ -394,13 +394,13 @@
                         {"operator": "=", "value": 9800}
                       ]
                   },{
-                      "and": [
+                      "or": [
                         {"operator": "<=", "value": "{REF_YEAR}"},
-                        {"operator": "!=", "value": 9800}
+                        {"operator": "=", "value": 9800}
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value 1 is not permitted or ref_year"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Value 1 is not permitted or {REF_YEAR}"
           }
       ]},
       {"id":"18400", "transformation":{"func":"DIRECT", "params":{"field":"sn_epis_inq"}}},
@@ -420,7 +420,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is lower than 3"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Value is lower than 3"
           }
       ]},
       {"id":"16400", "transformation":{"func":"DOMAIN", "params":{"field":"d_utilizzo", "domain_name": "D_UTILIZZO_OPERA"}}, "validations": [{
@@ -440,7 +440,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is lower than 3"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Value is lower than 3"
           }
       ]},
       {"id":"17500", "transformation":{"func":"DOMAIN", "params":{"field":"d_telecont", "domain_name": "D_TELECONT"}}},
@@ -455,7 +455,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value 1 is not permitted"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Value 1 is not permitted"
           }
       ]},
       {"id":"18500", "transformation":{"func":"DOMAIN", "params":{"field":"d_stato", "domain_name": "D_STATO"}}},
@@ -476,7 +476,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is not A or X"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Value is not A or X"
           }
       ]},
       {"id":"18700", "transformation":{"func":"DOMAIN", "params":{"field":"a_anno_ristr", "domain_name": "D_AFFIDABILITA"}}, "validations": [{
@@ -490,7 +490,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is not A"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Value is not A"
           }
       ]},
       {"id":"18900", "transformation":{"func":"DOMAIN", "params":{"field":"a_volume", "domain_name": "D_AFFIDABILITA"}}, "validations": [{
@@ -515,7 +515,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is not A or C"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Value is not A or C"
           }
       ]},
       {"id":"19100", "transformation":{"func":"DOMAIN", "params":{"field":"a_port_es", "domain_name": "D_AFFIDABILITA"}}, "validations": [{
@@ -528,7 +528,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is not A or C"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Value is not A or C"
           }
       ]},
       {"id":"19200", "transformation":{"func":"DOMAIN", "params":{"field":"a_port_uti_max", "domain_name": "D_AFFIDABILITA"}}, "validations": [{
@@ -554,7 +554,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is not A or C"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Value is not A or C"
           }
       ]},
       {"id":"19300", "transformation":{"func":"DOMAIN", "params":{"field":"a_port_uti_min", "domain_name": "D_AFFIDABILITA"}}, "validations": [{
@@ -580,7 +580,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is not A or C"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Value is not A or C"
           }
       ]},
 

--- a/export/config/current/sheet_configs/config_pozzi_pompe.json
+++ b/export/config/current/sheet_configs/config_pozzi_pompe.json
@@ -37,7 +37,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is lower than 3"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is lower than 3"
                 }
             ]},
       {"id":"20000", "transformation":{"func":"DIRECT", "params":{"field":"anno_instal"}}, "validations": [{
@@ -51,7 +51,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field greater than ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field greater than {REF_YEAR}"
                 }
             ]},
       {"id":"20100", "transformation":{"func":"DIRECT", "params":{"field":"anno_ristr"}}, "validations": [{
@@ -65,7 +65,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field greater than ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field greater than {REF_YEAR}"
                 }
             ]},
       {"id":"20200", "transformation":{"func":"DIRECT", "params":{"field":"potenza"}}},
@@ -88,7 +88,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not X or A"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is not X or A"
                 }
             ]},
       {"id":"20700", "transformation":{"func":"DIRECT", "params":{"field":"a_anno_ristr"}}, "validations": [{
@@ -102,7 +102,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not A"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is not A"
                 }
             ]},
       {"id":"20800", "transformation":{"func":"DIRECT", "params":{"field":"a_potenza"}}},

--- a/export/config/current/sheet_configs/config_pozzi_pompe.json
+++ b/export/config/current/sheet_configs/config_pozzi_pompe.json
@@ -45,9 +45,9 @@
                     "params": {
                         "field": "20000",
                         "cond": [{
-                            "and": [
-                              {"operator": ">=", "value": "{REF_YEAR}"},
-                              {"operator":  "!=", "value": 9999}
+                            "or": [
+                              {"operator": "<=", "value": "{REF_YEAR}"},
+                              {"operator":  "=", "value": 9999}
                             ]
                         }]
                     },
@@ -59,9 +59,9 @@
                     "params": {
                         "field": "20100",
                         "cond": [{
-                            "and": [
-                              {"operator": ">=", "value": "{REF_YEAR}"},
-                              {"operator":  "!=", "value": 9800}
+                            "or": [
+                              {"operator": "<=", "value": "{REF_YEAR}"},
+                              {"operator":  "=", "value": 9800}
                             ]
                         }]
                     },

--- a/export/config/current/sheet_configs/config_pozzi_pompe.json
+++ b/export/config/current/sheet_configs/config_pozzi_pompe.json
@@ -37,7 +37,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is lower than 3"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is lower than 3"
                 }
             ]},
       {"id":"20000", "transformation":{"func":"DIRECT", "params":{"field":"anno_instal"}}, "validations": [{
@@ -51,7 +51,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field greater than ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field greater than ref_year"
                 }
             ]},
       {"id":"20100", "transformation":{"func":"DIRECT", "params":{"field":"anno_ristr"}}, "validations": [{
@@ -65,7 +65,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field greater than ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field greater than ref_year"
                 }
             ]},
       {"id":"20200", "transformation":{"func":"DIRECT", "params":{"field":"potenza"}}},
@@ -88,7 +88,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is not X or A"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not X or A"
                 }
             ]},
       {"id":"20700", "transformation":{"func":"DIRECT", "params":{"field":"a_anno_ristr"}}, "validations": [{
@@ -102,7 +102,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is not A"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not A"
                 }
             ]},
       {"id":"20800", "transformation":{"func":"DIRECT", "params":{"field":"a_potenza"}}},

--- a/export/config/current/sheet_configs/config_scaricatori.json
+++ b/export/config/current/sheet_configs/config_scaricatori.json
@@ -130,7 +130,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field field is 0"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: field field is 0"
                 }
             ]},
       {"id":"83700", "transformation":{"func":"DIRECT", "params":{"field":"anno_costr"}}, "validations": [{
@@ -144,7 +144,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field greater than ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field greater than {REF_YEAR}"
                 }
             ]},
       {"id":"83800", "transformation":{"func":"DIRECT", "params":{"field":"anno_ristr"}}, "validations": [{
@@ -158,7 +158,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field greater than ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field greater than {REF_YEAR}"
                 }
             ]},
       {"id":"84000", "transformation":{"func":"DIRECT", "params":{"field":"n_ae"}}},
@@ -196,7 +196,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field greater than ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field greater than {REF_YEAR}"
                 }
             ]},
       {"id":"85100", "transformation":{"func":"DOMAIN", "params":{"field":"a_anno_ristr", "domain_name": "D_AFFIDABILITA"}}, "validations": [{
@@ -210,7 +210,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: value is not A"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: value is not A"
                 }
             ]},
 

--- a/export/config/current/sheet_configs/config_scaricatori.json
+++ b/export/config/current/sheet_configs/config_scaricatori.json
@@ -139,8 +139,8 @@
                         "field": "83700",
                         "cond": [{
                             "or": [
-                              {"operator": ">=", "value": "{REF_YEAR}"},
-                              {"operator":  "!=", "value": 9999}
+                              {"operator": "<=", "value": "{REF_YEAR}"},
+                              {"operator":  "=", "value": 9999}
                             ]
                         }]
                     },
@@ -153,8 +153,8 @@
                         "field": "83800",
                         "cond": [{
                             "or": [
-                              {"operator": ">=", "value": "{REF_YEAR}"},
-                              {"operator":  "!=", "value": 9800}
+                              {"operator": "<=", "value": "{REF_YEAR}"},
+                              {"operator":  "=", "value": 9800}
                             ]
                         }]
                     },

--- a/export/config/current/sheet_configs/config_scaricatori.json
+++ b/export/config/current/sheet_configs/config_scaricatori.json
@@ -130,7 +130,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: field field is 0"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field field is 0"
                 }
             ]},
       {"id":"83700", "transformation":{"func":"DIRECT", "params":{"field":"anno_costr"}}, "validations": [{
@@ -144,7 +144,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field greater than ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field greater than ref_year"
                 }
             ]},
       {"id":"83800", "transformation":{"func":"DIRECT", "params":{"field":"anno_ristr"}}, "validations": [{
@@ -158,7 +158,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field greater than ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field greater than ref_year"
                 }
             ]},
       {"id":"84000", "transformation":{"func":"DIRECT", "params":{"field":"n_ae"}}},
@@ -196,7 +196,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field greater than ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field greater than ref_year"
                 }
             ]},
       {"id":"85100", "transformation":{"func":"DOMAIN", "params":{"field":"a_anno_ristr", "domain_name": "D_AFFIDABILITA"}}, "validations": [{
@@ -210,7 +210,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: value is not A"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: value is not A"
                 }
             ]},
 

--- a/export/config/current/sheet_configs/config_sollev_pompe.json
+++ b/export/config/current/sheet_configs/config_sollev_pompe.json
@@ -33,8 +33,8 @@
                         "field": "66600",
                         "cond": [{
                             "or": [
-                              {"operator": ">=", "value": "{REF_YEAR}"},
-                              {"operator":  "!=", "value": 9999}
+                              {"operator": "<=", "value": "{REF_YEAR}"},
+                              {"operator":  "=", "value": 9999}
                             ]
                         }]
                     },
@@ -47,8 +47,8 @@
                         "field": "66700",
                         "cond": [{
                             "or": [
-                              {"operator": ">=", "value": "{REF_YEAR}"},
-                              {"operator":  "!=", "value": 9800}
+                              {"operator": "<=", "value": "{REF_YEAR}"},
+                              {"operator":  "=", "value": 9800}
                             ]
                         }]
                     },

--- a/export/config/current/sheet_configs/config_sollev_pompe.json
+++ b/export/config/current/sheet_configs/config_sollev_pompe.json
@@ -38,7 +38,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field greater than ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field greater than ref_year"
                 }
             ]},
       {"id":"66700", "transformation":{"func":"DIRECT", "params":{"field":"anno_ristr"}}, "validations": [{
@@ -52,7 +52,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field greater than ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field greater than ref_year"
                 }
             ]},
       {"id":"66800", "transformation":{"func":"DIRECT", "params":{"field":"potenza"}}},
@@ -75,7 +75,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is not X or A"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not X or A"
                 }
             ]},
         {"id":"67300", "transformation":{"func":"DIRECT", "params":{"field":"a_anno_ristr"}}, "validations": [{
@@ -89,7 +89,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is not A"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not A"
                 }
             ]},
       {"id":"67400", "transformation":{"func":"DIRECT", "params":{"field":"a_potenza"}}},

--- a/export/config/current/sheet_configs/config_sollev_pompe.json
+++ b/export/config/current/sheet_configs/config_sollev_pompe.json
@@ -38,7 +38,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field greater than ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field greater than {REF_YEAR}"
                 }
             ]},
       {"id":"66700", "transformation":{"func":"DIRECT", "params":{"field":"anno_ristr"}}, "validations": [{
@@ -52,7 +52,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field greater than ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field greater than {REF_YEAR}"
                 }
             ]},
       {"id":"66800", "transformation":{"func":"DIRECT", "params":{"field":"potenza"}}},
@@ -75,7 +75,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not X or A"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is not X or A"
                 }
             ]},
         {"id":"67300", "transformation":{"func":"DIRECT", "params":{"field":"a_anno_ristr"}}, "validations": [{
@@ -89,7 +89,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not A"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is not A"
                 }
             ]},
       {"id":"67400", "transformation":{"func":"DIRECT", "params":{"field":"a_potenza"}}},

--- a/export/config/current/sheet_configs/config_sollevamenti.json
+++ b/export/config/current/sheet_configs/config_sollevamenti.json
@@ -151,7 +151,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is 0"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: field is 0"
                 }
             ]},
       {"id":"64400", "transformation":{"func":"DIRECT", "params":{"field":"anno_costr"}}, "validations": [{
@@ -165,7 +165,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is lower than the ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: field is lower than the {REF_YEAR}"
                 }
             ]},
       {"id":"64500", "transformation":{"func":"DIRECT", "params":{"field":"anno_ristr_civ"}}, "validations": [{
@@ -179,7 +179,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is lower than the ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: field is lower than the {REF_YEAR}"
                 }
             ]},
       {"id":"64700", "transformation":{"func":"DIRECT", "params":{"field":"anno_ristr_elmec"}}, "validations": [{
@@ -193,7 +193,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is lower than the ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: field is lower than the {REF_YEAR}"
                 }
             ]},
       {"id":"65100", "transformation":{"func":"DIRECT", "params":{"field":"sn_sgrigliat"}}},
@@ -231,7 +231,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field field is lower than 3"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: field field is lower than 3"
                 }
             ]},
       {"id":"64800", "transformation":{"func":"DOMAIN", "params":{"field":"d_stato_cons_elmec", "domain_name": "D_STATO_CONS"}}},
@@ -254,7 +254,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field field is lower than 3"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: field field is lower than 3"
                 }
             ]},
       {"id":"65700", "transformation":{"func":"DOMAIN", "params":{"field":"a_anno_ristr_civ", "domain_name": "D_AFFIDABILITA"}}, "validations": [{
@@ -268,7 +268,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field field is lower than 3"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: field field is lower than 3"
                 }
             ]},
       {"id":"65800", "transformation":{"func":"DOMAIN", "params":{"field":"a_anno_ristr_elmec", "domain_name": "D_AFFIDABILITA"}}, "validations": [{
@@ -282,7 +282,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field field is lower than 3"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: field field is lower than 3"
                 }
             ]},
 

--- a/export/config/current/sheet_configs/config_sollevamenti.json
+++ b/export/config/current/sheet_configs/config_sollevamenti.json
@@ -151,7 +151,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: field is 0"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is 0"
                 }
             ]},
       {"id":"64400", "transformation":{"func":"DIRECT", "params":{"field":"anno_costr"}}, "validations": [{
@@ -165,7 +165,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: field is lower than the ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is lower than the ref_year"
                 }
             ]},
       {"id":"64500", "transformation":{"func":"DIRECT", "params":{"field":"anno_ristr_civ"}}, "validations": [{
@@ -179,7 +179,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: field is lower than the ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is lower than the ref_year"
                 }
             ]},
       {"id":"64700", "transformation":{"func":"DIRECT", "params":{"field":"anno_ristr_elmec"}}, "validations": [{
@@ -193,7 +193,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: field is lower than the ref_year"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field is lower than the ref_year"
                 }
             ]},
       {"id":"65100", "transformation":{"func":"DIRECT", "params":{"field":"sn_sgrigliat"}}},
@@ -231,7 +231,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: field field is lower than 3"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field field is lower than 3"
                 }
             ]},
       {"id":"64800", "transformation":{"func":"DOMAIN", "params":{"field":"d_stato_cons_elmec", "domain_name": "D_STATO_CONS"}}},
@@ -254,7 +254,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: field field is lower than 3"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field field is lower than 3"
                 }
             ]},
       {"id":"65700", "transformation":{"func":"DOMAIN", "params":{"field":"a_anno_ristr_civ", "domain_name": "D_AFFIDABILITA"}}, "validations": [{
@@ -268,7 +268,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: field field is lower than 3"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field field is lower than 3"
                 }
             ]},
       {"id":"65800", "transformation":{"func":"DOMAIN", "params":{"field":"a_anno_ristr_elmec", "domain_name": "D_AFFIDABILITA"}}, "validations": [{
@@ -282,7 +282,7 @@
                             ]
                         }]
                     },
-                    "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: field field is lower than 3"
+                    "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: field field is lower than 3"
                 }
             ]},
 

--- a/export/config/current/sheet_configs/config_sollevamenti.json
+++ b/export/config/current/sheet_configs/config_sollevamenti.json
@@ -160,8 +160,8 @@
                         "field": "64400",
                         "cond": [{
                             "or": [
-                              {"operator": ">=", "value": "{REF_YEAR}"},
-                              {"operator":  "!=", "value": 9999}
+                              {"operator": "<=", "value": "{REF_YEAR}"},
+                              {"operator":  "=", "value": 9999}
                             ]
                         }]
                     },
@@ -174,8 +174,8 @@
                         "field": "64500",
                         "cond": [{
                             "or": [
-                              {"operator": ">=", "value": "{REF_YEAR}"},
-                              {"operator":  "!=", "value": 9800}
+                              {"operator": "<=", "value": "{REF_YEAR}"},
+                              {"operator":  "=", "value": 9800}
                             ]
                         }]
                     },
@@ -188,8 +188,8 @@
                         "field": "64700",
                         "cond": [{
                             "or": [
-                              {"operator": ">=", "value": "{REF_YEAR}"},
-                              {"operator":  "!=", "value": 9800}
+                              {"operator": "<=", "value": "{REF_YEAR}"},
+                              {"operator":  "=", "value": 9800}
                             ]
                         }]
                     },

--- a/export/config/current/sheet_configs/config_sorgenti.json
+++ b/export/config/current/sheet_configs/config_sorgenti.json
@@ -202,7 +202,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is not lower than ID 24600"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not lower than ID 24600"
           }
       ]},
 
@@ -219,7 +219,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: value is not 0"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: value is not 0"
           }
       ]},
       {"id":"24300", "transformation":{"func":"DIRECT", "params":{"field":"denominazi"}}},
@@ -234,7 +234,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is lower than ID 26200"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is lower than ID 26200"
           }
       ]},
       {"id":"24700", "transformation":{"func":"DIRECT", "params":{"field":"port_industr"}}},
@@ -252,7 +252,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Value is not valid for the ref_year selected"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is not valid for year ref_year"
           }
       ]},
       {"id":"25200", "transformation":{"func":"DIRECT", "params":{"field":"anno_ristr"}},"validations": [{
@@ -266,7 +266,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Value is not valid for the ref_year selected"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is not valid for year ref_year"
           }
       ]},
       {"id":"25500", "transformation":{"func":"DIRECT", "params":{"field":"utilizzo_annuo"}}, "validations": [{
@@ -290,7 +290,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Value not permitted"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value not permitted"
           }
       ]},
       {"id":"25600", "transformation":{"func":"DIRECT", "params":{"field":"sn_cunic_presa"}}},
@@ -313,7 +313,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is lower than 0"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is lower than 0"
           }
       ]},
       {"id":"26300", "transformation":{"func":"DIRECT", "params":{"field":"port_uti_max"}}, "validations": [{
@@ -332,7 +332,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}"
           }
       ]},
       {"id":"26400", "transformation":{"func":"DIRECT", "params":{"field":"port_uti_min"}}, "validations": [{
@@ -351,7 +351,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field does not match the specifications"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field does not match the specifications"
           }
       ]},
       {"id":"26600", "transformation":{"func":"DIRECT", "params":{"field":"sn_strum_mis_port"}}},
@@ -371,7 +371,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field value not permitted for that ref_year"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field value not permitted for that ref_year"
           }
       ]},
       {"id":"27200", "transformation":{"func":"DIRECT", "params":{"field":"anno_ristr_clor"}}},
@@ -392,7 +392,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Value is lower than 3"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is lower than 3"
           }
       ]},
       {"id":"25400", "transformation":{"func":"DOMAIN", "params":{"field":"d_utilizzo", "domain_name": "D_UTILIZZO_OPERA"}}, "validations": [{
@@ -412,7 +412,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Value is lower than 3"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is lower than 3"
           }
       ]},
       {"id":"26500", "transformation":{"func":"DOMAIN", "params":{"field":"d_telecont", "domain_name": "D_TELECONT"}}},
@@ -427,7 +427,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is 1"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is 1"
           }
       ]},
       {"id":"27400", "transformation":{"func":"DOMAIN", "params":{"field":"d_stato", "domain_name": "D_STATO"}}},
@@ -448,7 +448,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is not A or X"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not A or X"
           }
       ]},
       {"id":"27600", "transformation":{"func":"DOMAIN", "params":{"field":"a_anno_ristr", "domain_name": "D_AFFIDABILITA"}},"validations": [{
@@ -462,7 +462,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is not A"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not A"
           }
       ]},
       {"id":"27700", "transformation":{"func":"DOMAIN", "params":{"field":"a_volume", "domain_name": "D_AFFIDABILITA"}},"validations": [{
@@ -487,7 +487,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is not A or C"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not A or C"
           }
       ]},
       {"id":"27900", "transformation":{"func":"DOMAIN", "params":{"field":"a_port_es", "domain_name": "D_AFFIDABILITA"}},"validations": [{
@@ -500,7 +500,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is not A or C"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not A or C"
           }
       ]},
       {"id":"28000", "transformation":{"func":"DOMAIN", "params":{"field":"a_port_uti_max", "domain_name": "D_AFFIDABILITA"}},"validations": [{
@@ -526,7 +526,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is not A or C"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not A or C"
           }
       ]},
       {"id":"28100", "transformation":{"func":"DOMAIN", "params":{"field":"a_port_uti_min", "domain_name": "D_AFFIDABILITA"}},"validations": [{
@@ -552,7 +552,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET} - Riga: {ROW}, Campo: {FIELD}: Field is not A or C"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not A or C"
           }
       ]},
 

--- a/export/config/current/sheet_configs/config_sorgenti.json
+++ b/export/config/current/sheet_configs/config_sorgenti.json
@@ -202,7 +202,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not lower than ID 24600"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is not lower than ID 24600"
           }
       ]},
 
@@ -219,7 +219,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: value is not 0"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: value is not 0"
           }
       ]},
       {"id":"24300", "transformation":{"func":"DIRECT", "params":{"field":"denominazi"}}},
@@ -234,7 +234,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is lower than ID 26200"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is lower than ID 26200"
           }
       ]},
       {"id":"24700", "transformation":{"func":"DIRECT", "params":{"field":"port_industr"}}},
@@ -252,7 +252,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is not valid for year ref_year"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Value is not valid for year {REF_YEAR}"
           }
       ]},
       {"id":"25200", "transformation":{"func":"DIRECT", "params":{"field":"anno_ristr"}},"validations": [{
@@ -266,7 +266,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is not valid for year ref_year"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Value is not valid for year {REF_YEAR}"
           }
       ]},
       {"id":"25500", "transformation":{"func":"DIRECT", "params":{"field":"utilizzo_annuo"}}, "validations": [{
@@ -290,7 +290,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value not permitted"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Value not permitted"
           }
       ]},
       {"id":"25600", "transformation":{"func":"DIRECT", "params":{"field":"sn_cunic_presa"}}},
@@ -313,7 +313,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is lower than 0"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is lower than 0"
           }
       ]},
       {"id":"26300", "transformation":{"func":"DIRECT", "params":{"field":"port_uti_max"}}, "validations": [{
@@ -332,7 +332,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}"
           }
       ]},
       {"id":"26400", "transformation":{"func":"DIRECT", "params":{"field":"port_uti_min"}}, "validations": [{
@@ -351,7 +351,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field does not match the specifications"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field does not match the specifications"
           }
       ]},
       {"id":"26600", "transformation":{"func":"DIRECT", "params":{"field":"sn_strum_mis_port"}}},
@@ -371,7 +371,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field value not permitted for that ref_year"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field value not permitted for that {REF_YEAR}"
           }
       ]},
       {"id":"27200", "transformation":{"func":"DIRECT", "params":{"field":"anno_ristr_clor"}}},
@@ -392,7 +392,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is lower than 3"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Value is lower than 3"
           }
       ]},
       {"id":"25400", "transformation":{"func":"DOMAIN", "params":{"field":"d_utilizzo", "domain_name": "D_UTILIZZO_OPERA"}}, "validations": [{
@@ -412,7 +412,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Value is lower than 3"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Value is lower than 3"
           }
       ]},
       {"id":"26500", "transformation":{"func":"DOMAIN", "params":{"field":"d_telecont", "domain_name": "D_TELECONT"}}},
@@ -427,7 +427,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is 1"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is 1"
           }
       ]},
       {"id":"27400", "transformation":{"func":"DOMAIN", "params":{"field":"d_stato", "domain_name": "D_STATO"}}},
@@ -448,7 +448,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not A or X"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is not A or X"
           }
       ]},
       {"id":"27600", "transformation":{"func":"DOMAIN", "params":{"field":"a_anno_ristr", "domain_name": "D_AFFIDABILITA"}},"validations": [{
@@ -462,7 +462,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not A"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is not A"
           }
       ]},
       {"id":"27700", "transformation":{"func":"DOMAIN", "params":{"field":"a_volume", "domain_name": "D_AFFIDABILITA"}},"validations": [{
@@ -487,7 +487,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not A or C"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is not A or C"
           }
       ]},
       {"id":"27900", "transformation":{"func":"DOMAIN", "params":{"field":"a_port_es", "domain_name": "D_AFFIDABILITA"}},"validations": [{
@@ -500,7 +500,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not A or C"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is not A or C"
           }
       ]},
       {"id":"28000", "transformation":{"func":"DOMAIN", "params":{"field":"a_port_uti_max", "domain_name": "D_AFFIDABILITA"}},"validations": [{
@@ -526,7 +526,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not A or C"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is not A or C"
           }
       ]},
       {"id":"28100", "transformation":{"func":"DOMAIN", "params":{"field":"a_port_uti_min", "domain_name": "D_AFFIDABILITA"}},"validations": [{
@@ -552,7 +552,7 @@
                       ]
                   }]
               },
-              "warning": "Foglio: {SHEET}, Riga:{ROW}, Campo: {FIELD}: Field is not A or C"
+              "warning": "Foglio: {SHEET}, Riga:{ROW}, Codice_ato: {CODICE_ATO}, Campo: {FIELD}: Field is not A or C"
           }
       ]},
 

--- a/export/config/current/sheet_configs/config_sorgenti.json
+++ b/export/config/current/sheet_configs/config_sorgenti.json
@@ -246,9 +246,9 @@
               "params": {
                   "field": "25100",
                   "cond": [{
-                      "and": [
+                      "or": [
                         {"operator": "<=", "value": "{REF_YEAR}"},
-                        {"operator": "!=", "value": 9999}
+                        {"operator": "=", "value": 9999}
                       ]
                   }]
               },
@@ -260,9 +260,9 @@
               "params": {
                   "field": "25200",
                   "cond": [{
-                      "and": [
+                      "or": [
                         {"operator": "<=", "value": "{REF_YEAR}"},
-                        {"operator": "!=", "value": 9800}
+                        {"operator": "=", "value": 9800}
                       ]
                   }]
               },


### PR DESCRIPTION
Progress
- [x] _Timestamp removed from the logger_
- [x] _Aalias for the column added instead of the letter_
- [x]  _log level for validation has been set to `WARNING`, `transformation` and the others log are still at `ERROR` level_
- [x] `codice_ato` _added as default to the log (warning and error), plus a new placeholder has been added:_
`{custom:alias_of_the_field_to_show_in_the_log}` _will print the the log the value of a specified alias decided in the configuration.
- [x] _ref_year is not replaced with {REF_YEAR} with the current year/freeze year. I changed the validation for the selected step, of course, all the validation needs a recheck from the client_
- [x] _The application logs that we produce are always on a single line. The multiline-logs are produced by the Python interpreter. I made a fix to try to catch as much error as possible and convert them into a single line_
